### PR TITLE
fix: unique index for columns cpf & nome_completo

### DIFF
--- a/priv/repo/migrations/20210728061626_create_user_auth_tables.exs
+++ b/priv/repo/migrations/20210728061626_create_user_auth_tables.exs
@@ -20,7 +20,9 @@ defmodule Fuschia.Repo.Migrations.CreateUsuariosAuthTables do
       timestamps()
     end
 
+    create unique_index(:user, [:cpf])
     create unique_index(:user, [:email])
+    create unique_index(:user, [:nome_completo])
 
     create table(:user_token) do
       add :token, :binary, null: false


### PR DESCRIPTION
# Descrição
Correção adicionando unique index para colunas cpf e nome_completo considerando que estas são chaves candidatas


## Stories relacionadas (clubhouse)
- [ch-39]



## Pontos para atenção
- Não há


## Possui novas configurações?
- Não


## Possui migrations?
- Se a feature adicionou alguma *migration* e como faz para rodar
