### PR TITLE
fix: adicionado pastas .nix e direnv ao gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,9 @@ fuschia-*.tar
 
 # Environment variables
 .env
+
+# Nix stuff
+/.nix-mix/
+/.nix-hex/
+/.postgres/
+/.direnv/


### PR DESCRIPTION
# Descrição
adicionado pastas "indesejadas" ao git no gitignore

## Stories relacionadas (clubhouse)
- Nenhum

## Pontos para atenção
- Nenhum


## Possui novas configurações?
- Atualização ao gitignore


## Possui migrations?
- Não
