### PR TITLE
hotfix/user table

### DIFF
--- a/lib/fuschia/context/auth_logs.ex
+++ b/lib/fuschia/context/auth_logs.ex
@@ -17,6 +17,6 @@ defmodule Fuschia.Context.AuthLogs do
 
   @spec create(String.t(), String.t(), %User{}) :: :ok
   def create(ip, user_agent, user) do
-    create(%{"ip" => ip, "user_agent" => user_agent, "user_id" => user.id})
+    create(%{"ip" => ip, "user_agent" => user_agent, "user_cpf" => user.cpf})
   end
 end

--- a/lib/fuschia/context/user_tokens.ex
+++ b/lib/fuschia/context/user_tokens.ex
@@ -75,10 +75,10 @@ defmodule Fuschia.Context.UserTokens do
   Gets all tokens for the given user for the given contexts.
   """
   def user_and_contexts_query(user, :all) do
-    from t in UserToken, where: t.user_id == ^user.id
+    from t in UserToken, where: t.user_cpf == ^user.cpf
   end
 
   def user_and_contexts_query(user, [_ | _] = contexts) do
-    from t in UserToken, where: t.user_id == ^user.id and t.context in ^contexts
+    from t in UserToken, where: t.user_cpf == ^user.cpf and t.context in ^contexts
   end
 end

--- a/lib/fuschia/context/users.ex
+++ b/lib/fuschia/context/users.ex
@@ -9,12 +9,14 @@ defmodule Fuschia.Context.Users do
   alias Fuschia.Entities.{Contato, User, UserToken}
   alias Fuschia.Repo
 
+  @spec list :: [%User{}]
   def list do
     query()
     |> preload_all()
     |> Repo.all()
   end
 
+  @spec one(String.t()) :: %User{} | nil
   def one(cpf) do
     query()
     |> preload_all()
@@ -67,6 +69,7 @@ defmodule Fuschia.Context.Users do
     end
   end
 
+  @spec create(map) :: {:ok, %User{}} | {:error, %Ecto.Changeset{}}
   def create(attrs) do
     with {:ok, user} <-
            %User{}
@@ -76,6 +79,7 @@ defmodule Fuschia.Context.Users do
     end
   end
 
+  @spec update(String.t(), map) :: {:ok, %User{}} | {:error, %Ecto.Changeset{}}
   def update(cpf, attrs) do
     with %User{} = user <- one(cpf),
          {:ok, updated} <-
@@ -197,17 +201,20 @@ defmodule Fuschia.Context.Users do
     |> Repo.exists?()
   end
 
+  @spec query :: %Ecto.Query{}
   def query do
     from u in User,
       left_join: contato in assoc(u, :contato),
       order_by: [desc: u.created_at]
   end
 
+  @spec preload_all(%Ecto.Query{}) :: %Ecto.Query{}
   def preload_all(%Ecto.Query{} = query) do
     query
     |> Ecto.Query.preload([:contato])
   end
 
+  @spec preload_all(%User{}) :: %User{}
   def preload_all(%User{} = user) do
     user
     |> Repo.preload([:contato])

--- a/lib/fuschia/entities/auth_log.ex
+++ b/lib/fuschia/entities/auth_log.ex
@@ -10,13 +10,14 @@ defmodule Fuschia.Entities.AuthLog do
   alias Fuschia.Entities.User
   alias Fuschia.Types.TrimmedString
 
-  @required_fields ~w(ip user_agent user_id)a
+  @required_fields ~w(ip user_agent user_cpf)a
 
+  @foreign_key_type :string
   schema "auth_log" do
     field :ip, TrimmedString
     field :user_agent, TrimmedString
 
-    belongs_to :user, User
+    belongs_to :user, User, foreign_key: :user_cpf, references: :cpf
 
     timestamps(updated_at: false)
   end
@@ -25,6 +26,6 @@ defmodule Fuschia.Entities.AuthLog do
     struct
     |> cast(attrs, @required_fields)
     |> validate_required(@required_fields)
-    |> foreign_key_constraint(:user_id)
+    |> foreign_key_constraint(:user_cpf)
   end
 end

--- a/lib/fuschia/entities/user.ex
+++ b/lib/fuschia/entities/user.ex
@@ -22,11 +22,11 @@ defmodule Fuschia.Entities.User do
 
   @cpf_format Formats.cpf()
 
+  @primary_key {:cpf, TrimmedString, [autogenerate: false]}
   schema "user" do
     field :password_hash, TrimmedString
     field :confirmed, :boolean, default: false
     field :data_nascimento, :date
-    field :cpf, TrimmedString
     field :last_seen, :utc_datetime_usec
     field :perfil, TrimmedString
     field :nome_completo, TrimmedString
@@ -98,7 +98,6 @@ defmodule Fuschia.Entities.User do
       celular: struct.contato.celular,
       nomeCompleto: struct.nome_completo,
       perfil: struct.perfil,
-      id: struct.id,
       permissoes: struct.permissoes,
       cpf: struct.cpf,
       dataNasc: struct.data_nascimento
@@ -156,7 +155,6 @@ defmodule Fuschia.Entities.User do
   defimpl Jason.Encoder, for: User do
     def encode(struct, opts) do
       %{
-        id: struct.id,
         nome_completo: struct.nome_completo,
         perfil: struct.perfil,
         ultimo_login: struct.last_seen,

--- a/lib/fuschia/entities/user_token.ex
+++ b/lib/fuschia/entities/user_token.ex
@@ -12,12 +12,13 @@ defmodule Fuschia.Entities.UserToken do
   @hash_algorithm :sha256
   @rand_size 32
 
+  @foreign_key_type :string
   schema "users_token" do
     field :token, :binary
     field :context, :string
     field :sent_to, :string
 
-    belongs_to :user, User
+    belongs_to :user, User, foreign_key: :user_cpf, references: :cpf
 
     timestamps(updated_at: false)
   end
@@ -31,7 +32,7 @@ defmodule Fuschia.Entities.UserToken do
   their email.
   """
   def build_email_token(user, context) do
-    build_hashed_token(user, context, user.email)
+    build_hashed_token(user, context, user.contato.email)
   end
 
   defp build_hashed_token(user, context, sent_to) do
@@ -43,7 +44,7 @@ defmodule Fuschia.Entities.UserToken do
        token: hashed_token,
        context: context,
        sent_to: sent_to,
-       user_id: user.id
+       user_cpf: user.cpf
      }}
   end
 end

--- a/lib/fuschia_web/auth/guardian.ex
+++ b/lib/fuschia_web/auth/guardian.ex
@@ -9,7 +9,7 @@ defmodule FuschiaWeb.Auth.Guardian do
   alias Fuschia.Entities.User
 
   def subject_for_token(user, _claims) do
-    sub = to_string(user.id)
+    sub = to_string(user.cpf)
 
     {:ok, sub}
   end

--- a/lib/fuschia_web/channels/user_socket.ex
+++ b/lib/fuschia_web/channels/user_socket.ex
@@ -9,7 +9,7 @@ defmodule FuschiaWeb.UserSocket do
   # verification, you can put default assigns into
   # the socket that will be set for all channels, ie
   #
-  #     {:ok, assign(socket, :user_id, verified_user_id)}
+  #     {:ok, assign(socket, :user_cpf, verified_user_cpf)}
   #
   # To deny connection, return `:error`.
   #
@@ -22,12 +22,12 @@ defmodule FuschiaWeb.UserSocket do
 
   # Socket id's are topics that allow you to identify all sockets for a given user:
   #
-  #     def id(socket), do: "user_socket:#{socket.assigns.user_id}"
+  #     def id(socket), do: "user_socket:#{socket.assigns.user_cpf}"
   #
   # Would allow you to broadcast a "disconnect" event and terminate
   # all active sockets and channels for a given user:
   #
-  #     FuschiaWeb.Endpoint.broadcast("user_socket:#{user.id}", "disconnect", %{})
+  #     FuschiaWeb.Endpoint.broadcast("user_socket:#{user.cpf}", "disconnect", %{})
   #
   # Returning `nil` makes this socket anonymous.
   @impl true

--- a/priv/repo/migrations/20210728061626_create_user_auth_tables.exs
+++ b/priv/repo/migrations/20210728061626_create_user_auth_tables.exs
@@ -4,8 +4,8 @@ defmodule Fuschia.Repo.Migrations.CreateUsuariosAuthTables do
   def change do
     execute &execute_up/0, &execute_down/0
 
-    create table(:user) do
-      add :cpf, :citext, null: false
+    create table(:user, primary_key: false) do
+      add :cpf, :citext, primary_key: true, null: false
       add :nome_completo, :string, null: false
       add :data_nascimento, :date, null: false
       add :perfil, :papel, default: "avulso", null: false
@@ -27,12 +27,13 @@ defmodule Fuschia.Repo.Migrations.CreateUsuariosAuthTables do
       add :context, :string, null: false
       add :sent_to, :string
 
-      add :user_id, references(:user, on_delete: :delete_all), null: false
+      add :user_cpf, references(:user, column: :cpf, type: :citext, on_delete: :delete_all),
+        null: false
 
       timestamps(updated_at: false)
     end
 
-    create index(:user_token, [:user_id])
+    create index(:user_token, [:user_cpf])
     create unique_index(:user_token, [:context, :token])
   end
 

--- a/priv/repo/migrations/20210728173851_create_auth_log.exs
+++ b/priv/repo/migrations/20210728173851_create_auth_log.exs
@@ -7,11 +7,11 @@ defmodule Fuschia.Repo.Migrations.AddAuthLog do
 
       add :ip, :string, null: false
       add :user_agent, :string, null: false
-      add :user_id, references(:user), null: false
+      add :user_cpf, references(:user, column: :cpf, type: :citext), null: false
     end
 
     create index(:auth_log, [:ip])
     create index(:auth_log, [:user_agent])
-    create index(:auth_log, [:user_id])
+    create index(:auth_log, [:user_cpf])
   end
 end

--- a/test/fuschia/context/auth_logs_test.exs
+++ b/test/fuschia/context/auth_logs_test.exs
@@ -18,18 +18,18 @@ defmodule Fuschia.AuthLogsTest do
 
       user = insert(:user)
 
-      result = AuthLogs.create(%{"ip" => @ip, "user_agent" => ua, "user_id" => user.id})
+      result = AuthLogs.create(%{"ip" => @ip, "user_agent" => ua, "user_cpf" => user.cpf})
       auth_log = get_log(@ip)
 
       assert result == :ok
       assert Map.get(auth_log, :ip) == @ip
       assert Map.get(auth_log, :user_agent) == ua
-      assert Map.get(auth_log, :user_id) == user.id
+      assert Map.get(auth_log, :user_cpf) == user.cpf
     end
 
     test "with error should return :ok" do
       user = build(:user)
-      result = AuthLogs.create(%{"user_id" => user})
+      result = AuthLogs.create(%{"user_cpf" => user})
       auth_log = get_log(@ip)
 
       assert result == :ok
@@ -50,7 +50,7 @@ defmodule Fuschia.AuthLogsTest do
       assert result == :ok
       assert Map.get(auth_log, :ip) == @ip
       assert Map.get(auth_log, :user_agent) == ua
-      assert Map.get(auth_log, :user_id) == user.id
+      assert Map.get(auth_log, :user_cpf) == user.cpf
     end
 
     test "with error should return :ok" do

--- a/test/fuschia/context/users_test.exs
+++ b/test/fuschia/context/users_test.exs
@@ -24,11 +24,11 @@ defmodule Fuschia.Context.UsersTest do
         |> insert()
         |> Users.preload_all()
 
-      assert user == Users.one(user.id)
+      assert user == Users.one(user.cpf)
     end
 
     test "when id is invalid, returns nil" do
-      assert is_nil(Users.one(0))
+      assert is_nil(Users.one(""))
     end
   end
 
@@ -145,7 +145,7 @@ defmodule Fuschia.Context.UsersTest do
 
     test "when all params are valid, updates a user" do
       assert {:ok, user} = Users.register(@valid_attrs)
-      assert {:ok, updated_user} = Users.update(user.id, @update_attrs)
+      assert {:ok, updated_user} = Users.update(user.cpf, @update_attrs)
 
       for key <- Map.keys(@update_attrs) do
         if key == :contato do
@@ -162,18 +162,18 @@ defmodule Fuschia.Context.UsersTest do
 
     test "when params are invalid, returns an error changeset" do
       assert {:ok, user} = Users.register(@valid_attrs)
-      assert {:error, %Ecto.Changeset{}} = Users.update(user.id, @invalid_attrs)
+      assert {:error, %Ecto.Changeset{}} = Users.update(user.cpf, @invalid_attrs)
     end
   end
 
   describe "exists?/1" do
     test "when id is valid, returns true" do
       user = insert(:user)
-      assert true == Users.exists?(user.id)
+      assert true == Users.exists?(user.cpf)
     end
 
     test "when id is invalid, returns false" do
-      assert false == Users.exists?(0)
+      assert false == Users.exists?("")
     end
   end
 end

--- a/test/fuschia/entities/auth_log_test.exs
+++ b/test/fuschia/entities/auth_log_test.exs
@@ -8,7 +8,7 @@ defmodule Fuschia.Entities.AuthLogTest do
       %{
         ip: "127.0.0.1",
         user_agent: "Mozilla/5.0",
-        user_id: 1
+        user_cpf: "665.171.560-70"
       }
     end
 
@@ -28,10 +28,10 @@ defmodule Fuschia.Entities.AuthLogTest do
       assert %{user_agent: ["can't be blank"]} = errors_on(AuthLog.changeset(%AuthLog{}, params))
     end
 
-    test "user_id must be required", default_params do
-      params = Map.delete(default_params, :user_id)
+    test "user_cpf must be required", default_params do
+      params = Map.delete(default_params, :user_cpf)
 
-      assert %{user_id: ["can't be blank"]} = errors_on(AuthLog.changeset(%AuthLog{}, params))
+      assert %{user_cpf: ["can't be blank"]} = errors_on(AuthLog.changeset(%AuthLog{}, params))
     end
   end
 end

--- a/test/support/factories/auth_log_factory.ex
+++ b/test/support/factories/auth_log_factory.ex
@@ -12,7 +12,7 @@ defmodule Fuschia.AuthLogFactory do
         %AuthLog{
           ip: "127.0.0.1",
           user_agent: user_agent,
-          user_id: 1
+          user_cpf: 1
         }
       end
     end

--- a/test/support/test_support.ex
+++ b/test/support/test_support.ex
@@ -13,7 +13,7 @@ defmodule CoreWeb.TestSupport do
   """
   @spec login(%Plug.Conn{}, %User{}) :: %Plug.Conn{}
   def login(conn, user) do
-    params = %{"email" => user.email, "password" => user.password}
+    params = %{"email" => user.contato.email, "password" => user.password}
 
     with {:ok, token} <- Guardian.authenticate(params),
          {:ok, _user} <- Guardian.user_claims(params) do


### PR DESCRIPTION
# Descrição
Usa o campo `cpf` como chave orimária do esquema `User` e adiciona `@spec` nas funções restantes do contexto `Users`


## Stories relacionadas (clubhouse)
- [ch-54]


## Pontos para atenção
Não há


## Possui novas configurações?
Não


## Possui migrations?
- Altera as migrations relacionadas a `User`, `AuthLog` e `UserToken`
