### PR TITLE
feature/entities context rebrand

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,6 +1,6 @@
 alias Fuschia.{Context, Entities}
-alias Fuschia.Context.{Cidades, Universidades, Users}
-alias Fuschia.Entities.{Cidade, Contato, User, Universidade}
+alias Fuschia.Context.{Cidades, LinhasPesquisas, Nucleos, Universidades, Users}
+alias Fuschia.Entities.{Cidade, Contato, LinhaPesquisa, Nucleo, User, Universidade}
 alias Fuschia.Repo
 
 colors_opts = [

--- a/.iex.exs
+++ b/.iex.exs
@@ -1,8 +1,7 @@
 alias Fuschia.{Context, Entities}
-
-alias Fuschia.Context.Users
-
+alias Fuschia.Context.{Universidades, Users}
 alias Fuschia.Entities.{Contato, User, Universidade}
+alias Fuschia.Repo
 
 colors_opts = [
   syntax_colors: [

--- a/.iex.exs
+++ b/.iex.exs
@@ -1,6 +1,6 @@
 alias Fuschia.{Context, Entities}
-alias Fuschia.Context.{Universidades, Users}
-alias Fuschia.Entities.{Contato, User, Universidade}
+alias Fuschia.Context.{Cidades, Universidades, Users}
+alias Fuschia.Entities.{Cidade, Contato, User, Universidade}
 alias Fuschia.Repo
 
 colors_opts = [

--- a/.iex.exs
+++ b/.iex.exs
@@ -2,7 +2,7 @@ alias Fuschia.{Context, Entities}
 
 alias Fuschia.Context.Users
 
-alias Fuschia.Entities.{Contato, User}
+alias Fuschia.Entities.{Contato, User, Universidade}
 
 colors_opts = [
   syntax_colors: [

--- a/lib/fuschia/context/cidades.ex
+++ b/lib/fuschia/context/cidades.ex
@@ -45,8 +45,8 @@ defmodule Fuschia.Context.Cidades do
 
   @spec query :: %Ecto.Query{}
   def query do
-    from u in Cidade,
-      order_by: [desc: u.created_at]
+    from c in Cidade,
+      order_by: [desc: c.created_at]
   end
 
   @spec preload_all(%Ecto.Query{}) :: %Ecto.Query{}

--- a/lib/fuschia/context/cidades.ex
+++ b/lib/fuschia/context/cidades.ex
@@ -1,0 +1,63 @@
+defmodule Fuschia.Context.Cidades do
+  @moduledoc """
+  Public Fuschia Cidade API
+  """
+
+  import Ecto.Query
+
+  alias Fuschia.Entities.Cidade
+  alias Fuschia.Repo
+
+  @spec list :: [%Cidade{}]
+  def list do
+    query()
+    |> preload_all()
+    |> Repo.all()
+  end
+
+  @spec one(String.t()) :: %Cidade{} | nil
+  def one(municipio) do
+    query()
+    |> preload_all()
+    |> Repo.get(municipio)
+  end
+
+  @spec create(map) :: {:ok, %Cidade{}} | {:error, %Ecto.Changeset{}}
+  def create(attrs) do
+    with {:ok, cidade} <-
+           %Cidade{}
+           |> Cidade.changeset(attrs)
+           |> Repo.insert() do
+      {:ok, preload_all(cidade)}
+    end
+  end
+
+  @spec update(String.t(), map) :: {:ok, %Cidade{}} | {:error, %Ecto.Changeset{}}
+  def update(nome, attrs) do
+    with %Cidade{} = cidade <- one(nome),
+         {:ok, updated} <-
+           cidade
+           |> Cidade.changeset(attrs)
+           |> Repo.update() do
+      {:ok, updated}
+    end
+  end
+
+  @spec query :: %Ecto.Query{}
+  def query do
+    from u in Cidade,
+      order_by: [desc: u.created_at]
+  end
+
+  @spec preload_all(%Ecto.Query{}) :: %Ecto.Query{}
+  def preload_all(%Ecto.Query{} = query) do
+    query
+    |> Ecto.Query.preload([:universidades])
+  end
+
+  @spec preload_all(%Cidade{}) :: %Cidade{}
+  def preload_all(%Cidade{} = cidade) do
+    cidade
+    |> Repo.preload([:universidades])
+  end
+end

--- a/lib/fuschia/context/linhas_pesquisas.ex
+++ b/lib/fuschia/context/linhas_pesquisas.ex
@@ -1,0 +1,72 @@
+defmodule Fuschia.Context.LinhasPesquisas do
+  @moduledoc """
+  Public Fuschia LinhaPesquisa API
+  """
+
+  import Ecto.Query
+
+  alias Fuschia.Entities.{LinhaPesquisa, Nucleo}
+  alias Fuschia.Repo
+
+  @spec list :: [%LinhaPesquisa{}]
+  def list do
+    query()
+    |> preload_all()
+    |> Repo.all()
+  end
+
+  @spec list_by_nucleo(String.t()) :: [%LinhaPesquisa{}]
+  def list_by_nucleo(nome) do
+    query()
+    |> join(:inner, [l], n in Nucleo, on: l.nucleo_nome == n.nome)
+    |> where([l], l.nucleo_nome == ^nome)
+    |> preload_all()
+    |> Repo.all()
+  end
+
+  @spec one(String.t()) :: %LinhaPesquisa{} | nil
+  def one(nome) do
+    query()
+    |> preload_all()
+    |> Repo.get(nome)
+  end
+
+  @spec create(map) :: {:ok, %LinhaPesquisa{}} | {:error, %Ecto.Changeset{}}
+  def create(attrs) do
+    with {:ok, linha_pesquisa} <-
+           %LinhaPesquisa{}
+           |> LinhaPesquisa.changeset(attrs)
+           |> Repo.insert() do
+      {:ok, preload_all(linha_pesquisa)}
+    end
+  end
+
+  @spec update(String.t(), map) :: {:ok, %LinhaPesquisa{}} | {:error, %Ecto.Changeset{}}
+  def update(nome, attrs) do
+    with %LinhaPesquisa{} = linha_pesquisa <- one(nome),
+         {:ok, updated} <-
+           linha_pesquisa
+           |> LinhaPesquisa.changeset(attrs)
+           |> Repo.update() do
+      {:ok, updated}
+    end
+  end
+
+  @spec query :: %Ecto.Query{}
+  def query do
+    from l in LinhaPesquisa,
+      order_by: [desc: l.created_at]
+  end
+
+  @spec preload_all(%Ecto.Query{}) :: %Ecto.Query{}
+  def preload_all(%Ecto.Query{} = query) do
+    query
+    |> Ecto.Query.preload(nucleo: [:linhas_pesquisa])
+  end
+
+  @spec preload_all(%LinhaPesquisa{}) :: %LinhaPesquisa{}
+  def preload_all(%LinhaPesquisa{} = linha_pesquisa) do
+    linha_pesquisa
+    |> Repo.preload(nucleo: [:linhas_pesquisa])
+  end
+end

--- a/lib/fuschia/context/nucleos.ex
+++ b/lib/fuschia/context/nucleos.ex
@@ -1,0 +1,63 @@
+defmodule Fuschia.Context.Nucleos do
+  @moduledoc """
+  Public Fuschia Nucleo API
+  """
+
+  import Ecto.Query
+
+  alias Fuschia.Entities.Nucleo
+  alias Fuschia.Repo
+
+  @spec list :: [%Nucleo{}]
+  def list do
+    query()
+    |> preload_all()
+    |> Repo.all()
+  end
+
+  @spec one(String.t()) :: %Nucleo{} | nil
+  def one(nome) do
+    query()
+    |> preload_all()
+    |> Repo.get(nome)
+  end
+
+  @spec create(map) :: {:ok, %Nucleo{}} | {:error, %Ecto.Changeset{}}
+  def create(attrs) do
+    with {:ok, nucleo} <-
+           %Nucleo{}
+           |> Nucleo.changeset(attrs)
+           |> Repo.insert() do
+      {:ok, preload_all(nucleo)}
+    end
+  end
+
+  @spec update(String.t(), map) :: {:ok, %Nucleo{}} | {:error, %Ecto.Changeset{}}
+  def update(nome, attrs) do
+    with %Nucleo{} = nucleo <- one(nome),
+         {:ok, updated} <-
+           nucleo
+           |> Nucleo.changeset(attrs)
+           |> Repo.update() do
+      {:ok, updated}
+    end
+  end
+
+  @spec query :: %Ecto.Query{}
+  def query do
+    from n in Nucleo,
+      order_by: [desc: n.created_at]
+  end
+
+  @spec preload_all(%Ecto.Query{}) :: %Ecto.Query{}
+  def preload_all(%Ecto.Query{} = query) do
+    query
+    |> Ecto.Query.preload([:linhas_pesquisa])
+  end
+
+  @spec preload_all(%Nucleo{}) :: %Nucleo{}
+  def preload_all(%Nucleo{} = nucleo) do
+    nucleo
+    |> Repo.preload([:linhas_pesquisa])
+  end
+end

--- a/lib/fuschia/context/universidades.ex
+++ b/lib/fuschia/context/universidades.ex
@@ -1,0 +1,72 @@
+defmodule Fuschia.Context.Universidades do
+  @moduledoc """
+  Public Fuschia Universidade API
+  """
+
+  import Ecto.Query
+
+  alias Fuschia.Entities.{Cidade, Universidade}
+  alias Fuschia.Repo
+
+  @spec list :: [%Universidade{}]
+  def list do
+    query()
+    |> preload_all()
+    |> Repo.all()
+  end
+
+  @spec list_by_municipio(String.t()) :: [%Universidade{}]
+  def list_by_municipio(municipio) do
+    query()
+    |> join(:inner, [u], c in Cidade, on: u.cidade_municipio == c.municipio)
+    |> where([u], u.cidade_municipio == ^municipio)
+    |> preload_all()
+    |> Repo.all()
+  end
+
+  @spec one(String.t()) :: %Universidade{} | nil
+  def one(nome) do
+    query()
+    |> preload_all()
+    |> Repo.get(nome)
+  end
+
+  @spec create(map) :: {:ok, %Universidade{}} | {:error, %Ecto.Changeset{}}
+  def create(attrs) do
+    with {:ok, universidade} <-
+           %Universidade{}
+           |> Universidade.changeset(attrs)
+           |> Repo.insert() do
+      {:ok, preload_all(universidade)}
+    end
+  end
+
+  @spec update(String.t(), map) :: {:ok, %Universidade{}} | {:error, %Ecto.Changeset{}}
+  def update(nome, attrs) do
+    with %Universidade{} = universidade <- one(nome),
+         {:ok, updated} <-
+           universidade
+           |> Universidade.changeset(attrs)
+           |> Repo.update() do
+      {:ok, updated}
+    end
+  end
+
+  @spec query :: %Ecto.Query{}
+  def query do
+    from u in Universidade,
+      order_by: [desc: u.created_at]
+  end
+
+  @spec preload_all(%Ecto.Query{}) :: %Ecto.Query{}
+  def preload_all(%Ecto.Query{} = query) do
+    query
+    |> Ecto.Query.preload([:cidade])
+  end
+
+  @spec preload_all(%Universidade{}) :: %Universidade{}
+  def preload_all(%Universidade{} = universidade) do
+    universidade
+    |> Repo.preload([:cidade])
+  end
+end

--- a/lib/fuschia/context/universidades.ex
+++ b/lib/fuschia/context/universidades.ex
@@ -31,11 +31,21 @@ defmodule Fuschia.Context.Universidades do
     |> Repo.get(nome)
   end
 
+  @spec create_with_cidade(map) :: {:ok, %Universidade{}} | {:error, %Ecto.Changeset{}}
+  def create_with_cidade(attrs) do
+    with {:ok, universidade} <-
+           %Universidade{}
+           |> Universidade.changeset(attrs)
+           |> Repo.insert() do
+      {:ok, preload_all(universidade)}
+    end
+  end
+
   @spec create(map) :: {:ok, %Universidade{}} | {:error, %Ecto.Changeset{}}
   def create(attrs) do
     with {:ok, universidade} <-
            %Universidade{}
-           |> Universidade.changeset(attrs)
+           |> Universidade.foreign_changeset(attrs)
            |> Repo.insert() do
       {:ok, preload_all(universidade)}
     end

--- a/lib/fuschia/context/universidades.ex
+++ b/lib/fuschia/context/universidades.ex
@@ -42,7 +42,7 @@ defmodule Fuschia.Context.Universidades do
   end
 
   @spec update(String.t(), map) :: {:ok, %Universidade{}} | {:error, %Ecto.Changeset{}}
-  def update(nome, attrs) do
+  def update(nome, %{nome: _} = attrs) do
     with %Universidade{} = universidade <- one(nome),
          {:ok, updated} <-
            universidade
@@ -61,12 +61,12 @@ defmodule Fuschia.Context.Universidades do
   @spec preload_all(%Ecto.Query{}) :: %Ecto.Query{}
   def preload_all(%Ecto.Query{} = query) do
     query
-    |> Ecto.Query.preload([:cidade])
+    |> Ecto.Query.preload(cidade: [:universidades])
   end
 
   @spec preload_all(%Universidade{}) :: %Universidade{}
   def preload_all(%Universidade{} = universidade) do
     universidade
-    |> Repo.preload([:cidade])
+    |> Repo.preload(cidade: [:universidades])
   end
 end

--- a/lib/fuschia/entities/cidade.ex
+++ b/lib/fuschia/entities/cidade.ex
@@ -7,6 +7,8 @@ defmodule Fuschia.Entities.Cidade do
 
   alias Fuschia.Entities.Universidade
 
+  @required_fields ~w(municipio)a
+
   @primary_key {:municipio, :string, []}
   schema "cidade" do
     has_many :universidades, Universidade
@@ -14,17 +16,17 @@ defmodule Fuschia.Entities.Cidade do
     timestamps()
   end
 
-  @doc false
   def changeset(%__MODULE__{} = struct, attrs) do
     struct
-    |> cast(attrs, [:municipio])
-    |> validate_required([:municipio])
+    |> cast(attrs, @required_fields)
+    |> validate_required(@required_fields)
   end
 
   defimpl Jason.Encoder, for: __MODULE__ do
     def encode(struct, opts) do
       %{
-        municipio: struct.municipio
+        municipio: struct.municipio,
+        universidades: struct.universidades
       }
       |> Fuschia.Encoder.encode(opts)
     end

--- a/lib/fuschia/entities/cidade.ex
+++ b/lib/fuschia/entities/cidade.ex
@@ -11,7 +11,7 @@ defmodule Fuschia.Entities.Cidade do
 
   @primary_key {:municipio, :string, []}
   schema "cidade" do
-    has_many :universidades, Universidade
+    has_many :universidades, Universidade, on_replace: :delete
 
     timestamps()
   end

--- a/lib/fuschia/entities/cidade.ex
+++ b/lib/fuschia/entities/cidade.ex
@@ -6,10 +6,11 @@ defmodule Fuschia.Entities.Cidade do
   import Ecto.Changeset
 
   alias Fuschia.Entities.Universidade
+  alias Fuschia.Types.CapitalizedString
 
   @required_fields ~w(municipio)a
 
-  @primary_key {:municipio, :string, []}
+  @primary_key {:municipio, CapitalizedString, []}
   schema "cidade" do
     has_many :universidades, Universidade, on_replace: :delete
 

--- a/lib/fuschia/entities/linha_pesquisa.ex
+++ b/lib/fuschia/entities/linha_pesquisa.ex
@@ -6,7 +6,7 @@ defmodule Fuschia.Entities.LinhaPesquisa do
   import Ecto.Changeset
 
   alias Fuschia.Entities.Nucleo
-  alias Fuschia.Types.TrimmedString
+  alias Fuschia.Types.{CapitalizedString, TrimmedString}
 
   @required_fields ~w(descricao_curta numero nucleo_nome)a
   @optional_fields ~w(descricao_longa)a
@@ -16,7 +16,10 @@ defmodule Fuschia.Entities.LinhaPesquisa do
     field :descricao_curta, TrimmedString
     field :descricao_longa, TrimmedString
 
-    belongs_to :nucleo, Nucleo, references: :nome, foreign_key: :nucleo_nome
+    belongs_to :nucleo, Nucleo,
+      references: :nome,
+      foreign_key: :nucleo_nome,
+      type: CapitalizedString
 
     timestamps()
   end

--- a/lib/fuschia/entities/linha_pesquisa.ex
+++ b/lib/fuschia/entities/linha_pesquisa.ex
@@ -8,13 +8,13 @@ defmodule Fuschia.Entities.LinhaPesquisa do
   alias Fuschia.Entities.Nucleo
   alias Fuschia.Types.TrimmedString
 
-  @required_fields ~w(descricao_curta numero_linha nucleo_nome)a
+  @required_fields ~w(descricao_curta numero nucleo_nome)a
   @optional_fields ~w(descricao_longa)a
 
   schema "linha_pesquisa" do
     field :descricao_curta, TrimmedString
     field :descricao_longa, TrimmedString
-    field :numero_linha, :integer
+    field :numero, :integer
 
     belongs_to :nucleo, Nucleo, references: :nome, foreign_key: :nucleo_nome
 
@@ -36,8 +36,8 @@ defmodule Fuschia.Entities.LinhaPesquisa do
       %{
         descricao_curta: struct.descricao_curta,
         descricao_longa: struct.descricao_longa,
-        numero_linha: struct.numero_linha,
-        nucleo_nome: struct.nucleo_nome
+        numero: struct.numero,
+        nucleo: struct.nucleo
       }
       |> Fuschia.Encoder.encode(opts)
     end

--- a/lib/fuschia/entities/linha_pesquisa.ex
+++ b/lib/fuschia/entities/linha_pesquisa.ex
@@ -11,10 +11,10 @@ defmodule Fuschia.Entities.LinhaPesquisa do
   @required_fields ~w(descricao_curta numero nucleo_nome)a
   @optional_fields ~w(descricao_longa)a
 
+  @primary_key {:numero, :integer, []}
   schema "linha_pesquisa" do
     field :descricao_curta, TrimmedString
     field :descricao_longa, TrimmedString
-    field :numero, :integer
 
     belongs_to :nucleo, Nucleo, references: :nome, foreign_key: :nucleo_nome
 
@@ -26,7 +26,7 @@ defmodule Fuschia.Entities.LinhaPesquisa do
     struct
     |> cast(attrs, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
-    |> unique_constraint([:numero_linha, :nucleo_nome], name: :numero_linha_nucleo_nome_index)
+    |> unique_constraint([:numero, :nucleo_nome], name: :numero_linha_nucleo_nome_index)
     |> validate_length(:descricao_curta, max: 50)
     |> validate_length(:descricao_longa, max: 280)
   end

--- a/lib/fuschia/entities/linha_pesquisa.ex
+++ b/lib/fuschia/entities/linha_pesquisa.ex
@@ -6,13 +6,14 @@ defmodule Fuschia.Entities.LinhaPesquisa do
   import Ecto.Changeset
 
   alias Fuschia.Entities.Nucleo
+  alias Fuschia.Types.TrimmedString
 
   @required_fields ~w(descricao_curta numero_linha nucleo_nome)a
   @optional_fields ~w(descricao_longa)a
 
   schema "linha_pesquisa" do
-    field :descricao_curta, :string
-    field :descricao_longa, :string
+    field :descricao_curta, TrimmedString
+    field :descricao_longa, TrimmedString
     field :numero_linha, :integer
 
     belongs_to :nucleo, Nucleo, references: :nome, foreign_key: :nucleo_nome

--- a/lib/fuschia/entities/linha_pesquisa.ex
+++ b/lib/fuschia/entities/linha_pesquisa.ex
@@ -29,7 +29,7 @@ defmodule Fuschia.Entities.LinhaPesquisa do
     struct
     |> cast(attrs, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
-    |> unique_constraint([:numero, :nucleo_nome], name: :numero_linha_nucleo_nome_index)
+    |> unique_constraint([:numero, :nucleo_nome])
     |> validate_length(:descricao_curta, max: 50)
     |> validate_length(:descricao_longa, max: 280)
   end

--- a/lib/fuschia/entities/nucleo.ex
+++ b/lib/fuschia/entities/nucleo.ex
@@ -6,11 +6,11 @@ defmodule Fuschia.Entities.Nucleo do
   import Ecto.Changeset
 
   alias Fuschia.Entities.LinhaPesquisa
+  alias Fuschia.Types.CapitalizedString
 
   @required_fields ~w(nome descricao)a
-  @optional_fields ~w()a
 
-  @primary_key {:nome, :string, []}
+  @primary_key {:nome, CapitalizedString, []}
   schema "nucleo" do
     field :descricao, :string
 
@@ -22,16 +22,17 @@ defmodule Fuschia.Entities.Nucleo do
   @doc false
   def changeset(%__MODULE__{} = struct, attrs) do
     struct
-    |> cast(attrs, @required_fields ++ @optional_fields)
+    |> cast(attrs, @required_fields)
     |> validate_required(@required_fields)
-    |> validate_length(:descricao_nucleo, max: 400)
+    |> validate_length(:descricao, max: 400)
   end
 
   defimpl Jason.Encoder, for: __MODULE__ do
     def encode(struct, opts) do
       %{
         nome: struct.nome,
-        descricao_nucleo: struct.descricao_nucleo
+        descricao: struct.descricao,
+        linhas_pesquisa: struct.linhas_pesquisa
       }
       |> Fuschia.Encoder.encode(opts)
     end

--- a/lib/fuschia/entities/universidade.ex
+++ b/lib/fuschia/entities/universidade.ex
@@ -25,6 +25,7 @@ defmodule Fuschia.Entities.Universidade do
     struct
     |> cast(attrs, @required_fields)
     |> validate_required(@required_fields)
+    |> unique_constraint(:nome)
     |> cast_assoc(:cidade, required: true)
   end
 

--- a/lib/fuschia/entities/universidade.ex
+++ b/lib/fuschia/entities/universidade.ex
@@ -7,24 +7,24 @@ defmodule Fuschia.Entities.Universidade do
 
   alias Fuschia.Entities.Cidade
 
-  @required_fields ~w(nome cidade_municipio)a
+  @required_fields ~w(nome)a
 
   @primary_key {:nome, :string, []}
   schema "universidade" do
     belongs_to :cidade, Cidade,
       type: :string,
+      on_replace: :delete,
       references: :municipio,
       foreign_key: :cidade_municipio
 
     timestamps()
   end
 
-  @doc false
   def changeset(%__MODULE__{} = struct, attrs) do
     struct
     |> cast(attrs, @required_fields)
     |> validate_required(@required_fields)
-    |> foreign_key_constraint(:cidade_municipio)
+    |> cast_assoc(:cidade, required: true)
   end
 
   defimpl Jason.Encoder, for: __MODULE__ do

--- a/lib/fuschia/entities/universidade.ex
+++ b/lib/fuschia/entities/universidade.ex
@@ -7,11 +7,12 @@ defmodule Fuschia.Entities.Universidade do
 
   alias Fuschia.Entities.Cidade
 
-  @required_fields ~w(nome)a
+  @required_fields ~w(nome cidade_municipio)a
 
   @primary_key {:nome, :string, []}
   schema "universidade" do
     belongs_to :cidade, Cidade,
+      type: :string,
       references: :municipio,
       foreign_key: :cidade_municipio
 
@@ -23,7 +24,7 @@ defmodule Fuschia.Entities.Universidade do
     struct
     |> cast(attrs, @required_fields)
     |> validate_required(@required_fields)
-    |> cast_assoc(:cidade, required: true)
+    |> foreign_key_constraint(:cidade_municipio)
   end
 
   defimpl Jason.Encoder, for: __MODULE__ do

--- a/lib/fuschia/entities/universidade.ex
+++ b/lib/fuschia/entities/universidade.ex
@@ -7,12 +7,10 @@ defmodule Fuschia.Entities.Universidade do
 
   alias Fuschia.Entities.Cidade
 
-  @required_fields ~w(nome cidade_municipio)a
-  @optional_fields ~w()a
+  @required_fields ~w(nome)a
 
+  @primary_key {:nome, :string, []}
   schema "universidade" do
-    field :nome, :string
-
     belongs_to :cidade, Cidade,
       references: :municipio,
       foreign_key: :cidade_municipio
@@ -23,15 +21,16 @@ defmodule Fuschia.Entities.Universidade do
   @doc false
   def changeset(%__MODULE__{} = struct, attrs) do
     struct
-    |> cast(attrs, @required_fields ++ @optional_fields)
+    |> cast(attrs, @required_fields)
     |> validate_required(@required_fields)
+    |> cast_assoc(:cidade, required: true)
   end
 
   defimpl Jason.Encoder, for: __MODULE__ do
     def encode(struct, opts) do
       %{
         nome: struct.nome,
-        cidade_municipio: struct.cidade_municipio
+        cidade: struct.cidade
       }
       |> Fuschia.Encoder.encode(opts)
     end

--- a/lib/fuschia/entities/universidade.ex
+++ b/lib/fuschia/entities/universidade.ex
@@ -6,10 +6,11 @@ defmodule Fuschia.Entities.Universidade do
   import Ecto.Changeset
 
   alias Fuschia.Entities.Cidade
+  alias Fuschia.Types.CapitalizedString
 
   @required_fields ~w(nome)a
 
-  @primary_key {:nome, :string, []}
+  @primary_key {:nome, CapitalizedString, []}
   schema "universidade" do
     belongs_to :cidade, Cidade,
       type: :string,

--- a/lib/fuschia/entities/universidade.ex
+++ b/lib/fuschia/entities/universidade.ex
@@ -29,6 +29,14 @@ defmodule Fuschia.Entities.Universidade do
     |> cast_assoc(:cidade, required: true)
   end
 
+  def foreign_changeset(%__MODULE__{} = struct, attrs) do
+    struct
+    |> cast(attrs, [:cidade_municipio | @required_fields])
+    |> validate_required([:cidade_municipio | @required_fields])
+    |> unique_constraint([:nome, :cidade_municipio], name: :universidade_nome_municipio_index)
+    |> foreign_key_constraint(:cidade_municipio)
+  end
+
   defimpl Jason.Encoder, for: __MODULE__ do
     def encode(struct, opts) do
       %{

--- a/lib/fuschia/entities/user.ex
+++ b/lib/fuschia/entities/user.ex
@@ -9,7 +9,7 @@ defmodule Fuschia.Entities.User do
 
   alias Fuschia.Common.Formats
   alias Fuschia.Entities.{Contato, User}
-  alias Fuschia.Types.TrimmedString
+  alias Fuschia.Types.{CapitalizedString, TrimmedString}
 
   @required_fields ~w(nome_completo cpf data_nascimento)a
   @optional_fields ~w(password confirmed last_seen nome_completo ativo perfil)a
@@ -29,7 +29,7 @@ defmodule Fuschia.Entities.User do
     field :data_nascimento, :date
     field :last_seen, :utc_datetime_usec
     field :perfil, TrimmedString
-    field :nome_completo, TrimmedString
+    field :nome_completo, CapitalizedString
     field :ativo, :boolean, default: true
     field :password, TrimmedString, virtual: true
     field :permissoes, :map, virtual: true

--- a/lib/fuschia/types/capitalized_string.ex
+++ b/lib/fuschia/types/capitalized_string.ex
@@ -1,7 +1,9 @@
-defmodule Fuschia.Types.UpcaseString do
+defmodule Fuschia.Types.CapitalizedString do
   @moduledoc """
-  Provides an upcased String Type
+  Provides a capitalized String Type
   """
+
+  import Fuschia.Parser, only: [capitalize_all_words: 1]
 
   @behaviour Ecto.Type
 
@@ -11,7 +13,7 @@ defmodule Fuschia.Types.UpcaseString do
     {:ok,
      binary
      |> String.trim()
-     |> String.upcase()}
+     |> capitalize_all_words()}
   end
 
   def cast(other), do: Ecto.Type.cast(:string, other)

--- a/priv/repo/migrations/20210726192706_create_universidade.exs
+++ b/priv/repo/migrations/20210726192706_create_universidade.exs
@@ -2,7 +2,7 @@ defmodule Fuschia.Repo.Migrations.CreateUniversidade do
   use Ecto.Migration
 
   def change do
-    create table(:universidade) do
+    create table(:universidade, primary_key: false) do
       add :nome, :string, null: false
 
       add :cidade_municipio,
@@ -12,8 +12,7 @@ defmodule Fuschia.Repo.Migrations.CreateUniversidade do
       timestamps()
     end
 
-    create unique_index(:universidade, [:nome, :cidade_municipio],
-             name: :universidade_cidade_index
-           )
+    create unique_index(:universidade, [:nome])
+    create unique_index(:universidade, [:cidade_municipio])
   end
 end

--- a/priv/repo/migrations/20210726192706_create_universidade.exs
+++ b/priv/repo/migrations/20210726192706_create_universidade.exs
@@ -12,7 +12,8 @@ defmodule Fuschia.Repo.Migrations.CreateUniversidade do
       timestamps()
     end
 
-    create unique_index(:universidade, [:nome])
-    create unique_index(:universidade, [:cidade_municipio])
+    create unique_index(:universidade, [:nome, :cidade_municipio],
+             name: :universidade_nome_municipio_index
+           )
   end
 end

--- a/priv/repo/migrations/20210726210228_create_linha_pesquisa.exs
+++ b/priv/repo/migrations/20210726210228_create_linha_pesquisa.exs
@@ -2,8 +2,8 @@ defmodule Fuschia.Repo.Migrations.CreateLinhaPesquisa do
   use Ecto.Migration
 
   def change do
-    create table(:linha_pesquisa) do
-      add :numero, :integer, null: false
+    create table(:linha_pesquisa, primary_key: false) do
+      add :numero, :integer, primary_key: true, null: false
 
       add :nucleo_nome, references(:nucleo, column: :nome, type: :string, on_delete: :delete_all),
         null: false
@@ -14,8 +14,7 @@ defmodule Fuschia.Repo.Migrations.CreateLinhaPesquisa do
       timestamps()
     end
 
-    create unique_index(:linha_pesquisa, [:numero, :nucleo_nome],
-             name: :numero_linha_nucleo_nome_index
-           )
+    create unique_index(:linha_pesquisa, [:numero])
+    create unique_index(:linha_pesquisa, [:nucleo_nome])
   end
 end

--- a/priv/repo/migrations/20210726210228_create_linha_pesquisa.exs
+++ b/priv/repo/migrations/20210726210228_create_linha_pesquisa.exs
@@ -3,7 +3,7 @@ defmodule Fuschia.Repo.Migrations.CreateLinhaPesquisa do
 
   def change do
     create table(:linha_pesquisa) do
-      add :numero_linha, :integer, null: false
+      add :numero, :integer, null: false
 
       add :nucleo_nome, references(:nucleo, column: :nome, type: :string, on_delete: :delete_all),
         null: false
@@ -14,7 +14,7 @@ defmodule Fuschia.Repo.Migrations.CreateLinhaPesquisa do
       timestamps()
     end
 
-    create unique_index(:linha_pesquisa, [:numero_linha, :nucleo_nome],
+    create unique_index(:linha_pesquisa, [:numero, :nucleo_nome],
              name: :numero_linha_nucleo_nome_index
            )
   end

--- a/test/fuschia/context/cidades_test.exs
+++ b/test/fuschia/context/cidades_test.exs
@@ -1,0 +1,80 @@
+defmodule Fuschia.Context.CidadesTest do
+  use Fuschia.DataCase, async: true
+
+  import Fuschia.Factory
+
+  alias Fuschia.Context.Cidades
+  alias Fuschia.Entities.Cidade
+
+  describe "list/0" do
+    test "return all cidades in database" do
+      cidade =
+        :cidade
+        |> insert()
+        |> Cidades.preload_all()
+
+      assert [cidade] == Cidades.list()
+    end
+  end
+
+  describe "one/1" do
+    test "when nome is valid, returns a cidade" do
+      cidade =
+        :cidade
+        |> insert()
+        |> Cidades.preload_all()
+
+      assert cidade == Cidades.one(cidade.municipio)
+    end
+
+    test "when id is invalid, returns nil" do
+      assert is_nil(Cidades.one(""))
+    end
+  end
+
+  describe "create/1" do
+    @valid_attrs %{
+      municipio: "Campos dos Goytacazes"
+    }
+
+    @invalid_attrs %{
+      municipio: nil
+    }
+
+    test "when all params are valid, creates an admin cidade" do
+      assert {:ok, %Cidade{}} = Cidades.create(@valid_attrs)
+    end
+
+    test "when params are invalid, returns an error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Cidades.create(@invalid_attrs)
+    end
+  end
+
+  describe "update/1" do
+    @valid_attrs %{
+      municipio: "Campos dos Goytacazes"
+    }
+
+    @update_attrs %{
+      municipio: "São Carlos"
+    }
+
+    @invalid_attrs %{
+      municipio: nil
+    }
+
+    test "when all params are valid, updates a cidade" do
+      assert {:ok, cidade} = Cidades.create(@valid_attrs)
+
+      assert {:ok, updated_cidade} = Cidades.update(cidade.municipio, @update_attrs)
+
+      assert updated_cidade.municipio == @update_attrs.municipio
+    end
+
+    test "when params are invalid, returns an error changeset" do
+      assert {:ok, cidade} = Cidades.create(@valid_attrs)
+
+      assert {:error, %Ecto.Changeset{}} = Cidades.update(cidade.municipio, @invalid_attrs)
+    end
+  end
+end

--- a/test/fuschia/context/linhas_pesquisas_test.exs
+++ b/test/fuschia/context/linhas_pesquisas_test.exs
@@ -1,0 +1,98 @@
+defmodule Fuschia.Context.LinhasPesquisasTest do
+  use Fuschia.DataCase, async: true
+
+  import Fuschia.Factory
+
+  alias Fuschia.Context.LinhasPesquisas
+  alias Fuschia.Entities.LinhaPesquisa
+
+  describe "list/0" do
+    test "return all linha_pesquisas in database" do
+      linha_pesquisa =
+        :linha_pesquisa
+        |> insert()
+        |> LinhasPesquisas.preload_all()
+
+      assert [linha_pesquisa] == LinhasPesquisas.list()
+    end
+  end
+
+  describe "list_by_nucleo/1" do
+    test "return all linha_pesquisas in database" do
+      linha_pesquisa =
+        :linha_pesquisa
+        |> insert()
+        |> LinhasPesquisas.preload_all()
+
+      assert [linha_pesquisa] == LinhasPesquisas.list_by_nucleo(linha_pesquisa.nucleo_nome)
+    end
+  end
+
+  describe "one/1" do
+    test "when numero is valid, returns a linha_pesquisa" do
+      linha_pesquisa =
+        :linha_pesquisa
+        |> insert()
+        |> LinhasPesquisas.preload_all()
+
+      assert linha_pesquisa == LinhasPesquisas.one(linha_pesquisa.numero)
+    end
+
+    test "when id is invalid, returns nil" do
+      assert is_nil(LinhasPesquisas.one(0))
+    end
+  end
+
+  describe "create/1" do
+    @invalid_attrs %{
+      numero: nil,
+      nucleo_nome: nil,
+      descricao_curta: nil,
+      descricao_longa: nil
+    }
+
+    test "when all params are valid, creates an admin linha_pesquisa" do
+      attrs = params_for(:linha_pesquisa)
+      assert {:ok, %LinhaPesquisa{}} = LinhasPesquisas.create(attrs)
+    end
+
+    test "when params are invalid, returns an error changeset" do
+      assert {:error, %Ecto.Changeset{}} = LinhasPesquisas.create(@invalid_attrs)
+    end
+  end
+
+  describe "update/1" do
+    @update_attrs %{
+      numero: 100,
+      descricao_curta: "Descricao Curta Teste",
+      descricao_longa: "Descricao Longa Teste"
+    }
+
+    @invalid_attrs %{
+      numero: nil,
+      nucleo_nome: nil,
+      descricao_curta: nil,
+      descricao_longa: nil
+    }
+
+    test "when all params are valid, updates a linha_pesquisa" do
+      attrs = params_for(:linha_pesquisa)
+      assert {:ok, linha_pesquisa} = LinhasPesquisas.create(attrs)
+
+      assert {:ok, updated_linha_pesquisa} =
+               LinhasPesquisas.update(linha_pesquisa.numero, @update_attrs)
+
+      assert updated_linha_pesquisa.numero == @update_attrs.numero
+      assert updated_linha_pesquisa.descricao_curta == @update_attrs.descricao_curta
+      assert updated_linha_pesquisa.descricao_longa == @update_attrs.descricao_longa
+    end
+
+    test "when params are invalid, returns an error changeset" do
+      attrs = params_for(:linha_pesquisa)
+      assert {:ok, linha_pesquisa} = LinhasPesquisas.create(attrs)
+
+      assert {:error, %Ecto.Changeset{}} =
+               LinhasPesquisas.update(linha_pesquisa.numero, @invalid_attrs)
+    end
+  end
+end

--- a/test/fuschia/context/nucleos_test.exs
+++ b/test/fuschia/context/nucleos_test.exs
@@ -1,0 +1,79 @@
+defmodule Fuschia.Context.NucleosTest do
+  use Fuschia.DataCase, async: true
+
+  import Fuschia.Factory
+
+  alias Fuschia.Context.Nucleos
+  alias Fuschia.Entities.Nucleo
+
+  describe "list/0" do
+    test "return all nucleos in database" do
+      nucleo =
+        :nucleo
+        |> insert()
+        |> Nucleos.preload_all()
+
+      assert [nucleo] == Nucleos.list()
+    end
+  end
+
+  describe "one/1" do
+    test "when nome is valid, returns a nucleo" do
+      nucleo =
+        :nucleo
+        |> insert()
+        |> Nucleos.preload_all()
+
+      assert nucleo == Nucleos.one(nucleo.nome)
+    end
+
+    test "when id is invalid, returns nil" do
+      assert is_nil(Nucleos.one(""))
+    end
+  end
+
+  describe "create/1" do
+    @invalid_attrs %{
+      nome: nil,
+      descricao: nil
+    }
+
+    test "when all params are valid, creates an admin nucleo" do
+      attrs = params_for(:nucleo)
+      assert {:ok, %Nucleo{}} = Nucleos.create(attrs)
+    end
+
+    test "when params are invalid, returns an error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Nucleos.create(@invalid_attrs)
+    end
+  end
+
+  describe "update/1" do
+    @update_attrs %{
+      nome: "Nucleo Teste",
+      descricao: "Nucleo Descricao Teste"
+    }
+
+    @invalid_attrs %{
+      nome: nil,
+      descricao: nil
+    }
+
+    test "when all params are valid, updates a nucleo" do
+      attrs = params_for(:nucleo)
+      assert {:ok, nucleo} = Nucleos.create(attrs)
+
+      assert {:ok, updated_nucleo} = Nucleos.update(nucleo.nome, @update_attrs)
+
+      assert updated_nucleo.nome == @update_attrs.nome
+      assert updated_nucleo.descricao == @update_attrs.descricao
+    end
+
+    test "when params are invalid, returns an error changeset" do
+      attrs = params_for(:nucleo)
+      assert {:ok, nucleo} = Nucleos.create(attrs)
+
+      assert {:error, %Ecto.Changeset{}} = Nucleos.update(nucleo.nome, @invalid_attrs)
+    end
+  end
+end

--- a/test/fuschia/context/universidades_test.exs
+++ b/test/fuschia/context/universidades_test.exs
@@ -30,11 +30,9 @@ defmodule Fuschia.Context.UniversidadesTest do
 
   describe "one/1" do
     test "when nome is valid, returns a universidade" do
-      %{municipio: cidade_municipio} = insert(:cidade)
-
       universidade =
         :universidade
-        |> insert(cidade_municipio: cidade_municipio)
+        |> insert()
         |> Universidades.preload_all()
 
       assert universidade == Universidades.one(universidade.nome)
@@ -48,7 +46,7 @@ defmodule Fuschia.Context.UniversidadesTest do
   describe "create/1" do
     @valid_attrs %{
       nome: "Universidade Estadual do Norte Fluminence Darcy Ribeiro",
-      cidade_municipio: "Campos dos Goytacazes"
+      cidade: %{municipio: "Campos dos Goytacazes"}
     }
 
     @invalid_attrs %{
@@ -57,12 +55,7 @@ defmodule Fuschia.Context.UniversidadesTest do
     }
 
     test "when all params are valid, creates an admin universidade" do
-      %{municipio: cidade_municipio} = insert(:cidade)
-
-      assert {:ok, %Universidade{}} =
-               @valid_attrs
-               |> Map.put(:cidade_municipio, cidade_municipio)
-               |> Universidades.create()
+      assert {:ok, %Universidade{}} = Universidades.create(@valid_attrs)
     end
 
     test "when params are invalid, returns an error changeset" do
@@ -71,12 +64,9 @@ defmodule Fuschia.Context.UniversidadesTest do
   end
 
   describe "update/1" do
-    setup do
-      %{cidade: insert(:cidade)}
-    end
-
     @valid_attrs %{
-      nome: "Universidade Estadual do Norte Fluminence Darcy Ribeiro"
+      nome: "Universidade Estadual do Norte Fluminence Darcy Ribeiro",
+      cidade: %{municipio: "Campos dos Goytacazes"}
     }
 
     @update_attrs %{
@@ -84,27 +74,19 @@ defmodule Fuschia.Context.UniversidadesTest do
     }
 
     @invalid_attrs %{
-      nome: nil,
-      cidade_municipio: nil
+      nome: nil
     }
 
-    test "when all params are valid, updates a universidade", %{cidade: cidade} do
-      assert {:ok, universidade} =
-               @valid_attrs
-               |> Map.put(:cidade_municipio, cidade.municipio)
-               |> Universidades.create()
+    test "when all params are valid, updates a universidade" do
+      assert {:ok, universidade} = Universidades.create(@valid_attrs)
 
       assert {:ok, updated_universidade} = Universidades.update(universidade.nome, @update_attrs)
 
       assert updated_universidade.nome == @update_attrs.nome
-      assert updated_universidade.cidade_municipio == cidade.municipio
     end
 
-    test "when params are invalid, returns an error changeset", %{cidade: cidade} do
-      assert {:ok, universidade} =
-               @valid_attrs
-               |> Map.put(:cidade_municipio, cidade.municipio)
-               |> Universidades.create()
+    test "when params are invalid, returns an error changeset" do
+      assert {:ok, universidade} = Universidades.create(@valid_attrs)
 
       assert {:error, %Ecto.Changeset{}} = Universidades.update(universidade.nome, @invalid_attrs)
     end

--- a/test/fuschia/context/universidades_test.exs
+++ b/test/fuschia/context/universidades_test.exs
@@ -43,7 +43,7 @@ defmodule Fuschia.Context.UniversidadesTest do
     end
   end
 
-  describe "create/1" do
+  describe "create_with_cidade/1" do
     @valid_attrs %{
       nome: "Universidade Estadual do Norte Fluminence Darcy Ribeiro",
       cidade: %{municipio: "Campos dos Goytacazes"}
@@ -55,6 +55,27 @@ defmodule Fuschia.Context.UniversidadesTest do
     }
 
     test "when all params are valid, creates an admin universidade" do
+      assert {:ok, %Universidade{}} = Universidades.create_with_cidade(@valid_attrs)
+    end
+
+    test "when params are invalid, returns an error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Universidades.create_with_cidade(@invalid_attrs)
+    end
+  end
+
+  describe "create/1" do
+    @valid_attrs %{
+      nome: "Universidade Estadual do Norte Fluminence Darcy Ribeiro",
+      cidade_municipio: "Campos Dos Goytacazes"
+    }
+
+    @invalid_attrs %{
+      nome: nil,
+      cidade_municipio: nil
+    }
+
+    test "when all params are valid, creates an admin universidade" do
+      insert(:cidade, municipio: "Campos dos Goytacazes")
       assert {:ok, %Universidade{}} = Universidades.create(@valid_attrs)
     end
 
@@ -78,7 +99,7 @@ defmodule Fuschia.Context.UniversidadesTest do
     }
 
     test "when all params are valid, updates a universidade" do
-      assert {:ok, universidade} = Universidades.create(@valid_attrs)
+      assert {:ok, universidade} = Universidades.create_with_cidade(@valid_attrs)
 
       assert {:ok, updated_universidade} = Universidades.update(universidade.nome, @update_attrs)
 
@@ -86,7 +107,7 @@ defmodule Fuschia.Context.UniversidadesTest do
     end
 
     test "when params are invalid, returns an error changeset" do
-      assert {:ok, universidade} = Universidades.create(@valid_attrs)
+      assert {:ok, universidade} = Universidades.create_with_cidade(@valid_attrs)
 
       assert {:error, %Ecto.Changeset{}} = Universidades.update(universidade.nome, @invalid_attrs)
     end

--- a/test/fuschia/context/universidades_test.exs
+++ b/test/fuschia/context/universidades_test.exs
@@ -1,0 +1,112 @@
+defmodule Fuschia.Context.UniversidadesTest do
+  use Fuschia.DataCase, async: true
+
+  import Fuschia.Factory
+
+  alias Fuschia.Context.Universidades
+  alias Fuschia.Entities.Universidade
+
+  describe "list/0" do
+    test "return all universidades in database" do
+      universidade =
+        :universidade
+        |> insert()
+        |> Universidades.preload_all()
+
+      assert [universidade] == Universidades.list()
+    end
+  end
+
+  describe "list_by_municipio/1" do
+    test "return all universidades in database" do
+      universidade =
+        :universidade
+        |> insert()
+        |> Universidades.preload_all()
+
+      assert [universidade] == Universidades.list_by_municipio(universidade.cidade_municipio)
+    end
+  end
+
+  describe "one/1" do
+    test "when nome is valid, returns a universidade" do
+      %{municipio: cidade_municipio} = insert(:cidade)
+
+      universidade =
+        :universidade
+        |> insert(cidade_municipio: cidade_municipio)
+        |> Universidades.preload_all()
+
+      assert universidade == Universidades.one(universidade.nome)
+    end
+
+    test "when id is invalid, returns nil" do
+      assert is_nil(Universidades.one(""))
+    end
+  end
+
+  describe "create/1" do
+    @valid_attrs %{
+      nome: "Universidade Estadual do Norte Fluminence Darcy Ribeiro",
+      cidade_municipio: "Campos dos Goytacazes"
+    }
+
+    @invalid_attrs %{
+      nome: nil,
+      cidade: nil
+    }
+
+    test "when all params are valid, creates an admin universidade" do
+      %{municipio: cidade_municipio} = insert(:cidade)
+
+      assert {:ok, %Universidade{}} =
+               @valid_attrs
+               |> Map.put(:cidade_municipio, cidade_municipio)
+               |> Universidades.create()
+    end
+
+    test "when params are invalid, returns an error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Universidades.create(@invalid_attrs)
+    end
+  end
+
+  describe "update/1" do
+    setup do
+      %{cidade: insert(:cidade)}
+    end
+
+    @valid_attrs %{
+      nome: "Universidade Estadual do Norte Fluminence Darcy Ribeiro"
+    }
+
+    @update_attrs %{
+      nome: "Universidade Federal de São Carlos"
+    }
+
+    @invalid_attrs %{
+      nome: nil,
+      cidade_municipio: nil
+    }
+
+    test "when all params are valid, updates a universidade", %{cidade: cidade} do
+      assert {:ok, universidade} =
+               @valid_attrs
+               |> Map.put(:cidade_municipio, cidade.municipio)
+               |> Universidades.create()
+
+      assert {:ok, updated_universidade} = Universidades.update(universidade.nome, @update_attrs)
+
+      assert updated_universidade.nome == @update_attrs.nome
+      assert updated_universidade.cidade_municipio == cidade.municipio
+    end
+
+    test "when params are invalid, returns an error changeset", %{cidade: cidade} do
+      assert {:ok, universidade} =
+               @valid_attrs
+               |> Map.put(:cidade_municipio, cidade.municipio)
+               |> Universidades.create()
+
+      assert {:error, %Ecto.Changeset{}} = Universidades.update(universidade.nome, @invalid_attrs)
+    end
+  end
+end

--- a/test/fuschia/context/universidades_test.exs
+++ b/test/fuschia/context/universidades_test.exs
@@ -70,7 +70,7 @@ defmodule Fuschia.Context.UniversidadesTest do
     }
 
     @update_attrs %{
-      nome: "Universidade Federal de São Carlos"
+      nome: "Universidade Federal De São Carlos"
     }
 
     @invalid_attrs %{

--- a/test/fuschia/context/users_test.exs
+++ b/test/fuschia/context/users_test.exs
@@ -125,7 +125,7 @@ defmodule Fuschia.Context.UsersTest do
 
     @update_attrs %{
       cpf: "435.618.970-10",
-      nome_completo: "Juninho teste",
+      nome_completo: "Juninho Teste",
       data_nascimento: ~D[1990-07-27],
       contato: %{
         endereco: "Av Teste, Rua Teste, numero 765",

--- a/test/fuschia/entities/cidade_test.exs
+++ b/test/fuschia/entities/cidade_test.exs
@@ -1,0 +1,20 @@
+defmodule Fuschia.Entities.CidadeTest do
+  use Fuschia.DataCase, async: true
+
+  import Fuschia.Factory
+
+  alias Fuschia.Entities.Cidade
+
+  describe "changeset/2" do
+    @invalid_params %{municipio: nil}
+
+    test "when all params are valid, return a valid changeset" do
+      default_params = params_for(:cidade)
+      assert %Ecto.Changeset{valid?: true} = Cidade.changeset(%Cidade{}, default_params)
+    end
+
+    test "when params are invalid, return an error changeset" do
+      assert %Ecto.Changeset{valid?: false} = Cidade.changeset(%Cidade{}, @invalid_params)
+    end
+  end
+end

--- a/test/fuschia/entities/linha_pesquisa_test.exs
+++ b/test/fuschia/entities/linha_pesquisa_test.exs
@@ -1,0 +1,28 @@
+defmodule Fuschia.Entities.LinhaPesquisaTest do
+  use Fuschia.DataCase, async: true
+
+  import Fuschia.Factory
+
+  alias Fuschia.Entities.LinhaPesquisa
+
+  describe "changeset/2" do
+    @invalid_params %{
+      numero: nil,
+      nucleo_nome: nil,
+      descricao_curta: nil,
+      descricao_longa: nil
+    }
+
+    test "when all params are valid, return a valid changeset" do
+      default_params = params_for(:linha_pesquisa)
+
+      assert %Ecto.Changeset{valid?: true} =
+               LinhaPesquisa.changeset(%LinhaPesquisa{}, default_params)
+    end
+
+    test "when params are invalid, return an error changeset" do
+      assert %Ecto.Changeset{valid?: false} =
+               LinhaPesquisa.changeset(%LinhaPesquisa{}, @invalid_params)
+    end
+  end
+end

--- a/test/fuschia/entities/nucleo_test.exs
+++ b/test/fuschia/entities/nucleo_test.exs
@@ -1,0 +1,23 @@
+defmodule Fuschia.Entities.NucleoTest do
+  use Fuschia.DataCase, async: true
+
+  import Fuschia.Factory
+
+  alias Fuschia.Entities.Nucleo
+
+  describe "changeset/2" do
+    @invalid_params %{
+      nome: nil,
+      descricao: nil
+    }
+
+    test "when all params are valid, return a valid changeset" do
+      default_params = params_for(:nucleo)
+      assert %Ecto.Changeset{valid?: true} = Nucleo.changeset(%Nucleo{}, default_params)
+    end
+
+    test "when params are invalid, return an error changeset" do
+      assert %Ecto.Changeset{valid?: false} = Nucleo.changeset(%Nucleo{}, @invalid_params)
+    end
+  end
+end

--- a/test/fuschia/entities/universidade_test.exs
+++ b/test/fuschia/entities/universidade_test.exs
@@ -1,0 +1,24 @@
+defmodule Fuschia.Entities.UniversidadeTest do
+  use Fuschia.DataCase, async: true
+
+  import Fuschia.Factory
+
+  alias Fuschia.Entities.Universidade
+
+  describe "changeset/2" do
+    @invalid_params %{nome: nil, cidade: nil}
+
+    test "when all params are valid, return a valid changeset" do
+      cidade = params_for(:cidade)
+      default_params = params_for(:universidade) |> Map.put(:cidade, cidade)
+
+      assert %Ecto.Changeset{valid?: true} =
+               Universidade.changeset(%Universidade{}, default_params)
+    end
+
+    test "when params are invalid, return an error changeset" do
+      assert %Ecto.Changeset{valid?: false} =
+               Universidade.changeset(%Universidade{}, @invalid_params)
+    end
+  end
+end

--- a/test/fuschia/entities/universidade_test.exs
+++ b/test/fuschia/entities/universidade_test.exs
@@ -9,8 +9,8 @@ defmodule Fuschia.Entities.UniversidadeTest do
     @invalid_params %{nome: nil, cidade: nil}
 
     test "when all params are valid, return a valid changeset" do
-      cidade = params_for(:cidade)
-      default_params = params_for(:universidade) |> Map.put(:cidade, cidade)
+      %{municipio: cidade_municipio} = insert(:cidade)
+      default_params = params_for(:universidade) |> Map.put(:cidade_municipio, cidade_municipio)
 
       assert %Ecto.Changeset{valid?: true} =
                Universidade.changeset(%Universidade{}, default_params)

--- a/test/fuschia/entities/universidade_test.exs
+++ b/test/fuschia/entities/universidade_test.exs
@@ -9,8 +9,12 @@ defmodule Fuschia.Entities.UniversidadeTest do
     @invalid_params %{nome: nil, cidade: nil}
 
     test "when all params are valid, return a valid changeset" do
-      %{municipio: cidade_municipio} = insert(:cidade)
-      default_params = params_for(:universidade) |> Map.put(:cidade_municipio, cidade_municipio)
+      cidade = params_for(:cidade)
+
+      default_params =
+        :universidade
+        |> params_for()
+        |> Map.put(:cidade, cidade)
 
       assert %Ecto.Changeset{valid?: true} =
                Universidade.changeset(%Universidade{}, default_params)

--- a/test/fuschia/entities/user_test.exs
+++ b/test/fuschia/entities/user_test.exs
@@ -10,9 +10,7 @@ defmodule Fuschia.Entities.UserTest do
       cpf: nil,
       contato: nil,
       data_nascimento: nil,
-      nome_completo: nil,
-      password: nil,
-      password_confirmation: nil
+      nome_completo: nil
     }
 
     test "when all params are valid, return a valid changeset" do
@@ -22,6 +20,58 @@ defmodule Fuschia.Entities.UserTest do
 
     test "when params are invalid, return an error changeset" do
       assert %Ecto.Changeset{valid?: false} = User.changeset(%User{}, @invalid_params)
+    end
+  end
+
+  describe "admin_changeset/2" do
+    @invalid_params %{
+      cpf: nil,
+      perfil: nil,
+      contato: nil,
+      data_nascimento: nil,
+      nome_completo: nil
+    }
+
+    test "when all params are valid, return a valid changeset" do
+      contato = params_for(:contato)
+
+      default_params =
+        params_for(:user)
+        |> Map.put(:contato, contato)
+        |> Map.put(:perfil, "admin")
+
+      assert %Ecto.Changeset{valid?: true} = User.changeset(%User{}, default_params)
+    end
+
+    test "when params are invalid, return an error changeset" do
+      assert %Ecto.Changeset{valid?: false} = User.changeset(%User{}, @invalid_params)
+    end
+  end
+
+  describe "registration_changeset/2" do
+    @invalid_params %{
+      cpf: nil,
+      contato: nil,
+      data_nascimento: nil,
+      nome_completo: nil,
+      password: nil,
+      password_confirmation: nil
+    }
+
+    test "when all params are valid, return a valid changeset" do
+      contato = params_for(:contato)
+
+      default_params =
+        params_for(:user)
+        |> Map.put(:contato, contato)
+        |> Map.merge(%{password: "minhaSenha123", password_confirmation: "minhaSenha123"})
+
+      assert %Ecto.Changeset{valid?: true} = User.registration_changeset(%User{}, default_params)
+    end
+
+    test "when params are invalid, return an error changeset" do
+      assert %Ecto.Changeset{valid?: false} =
+               User.registration_changeset(%User{}, @invalid_params)
     end
   end
 end

--- a/test/support/factories/cidade_factory.ex
+++ b/test/support/factories/cidade_factory.ex
@@ -1,0 +1,15 @@
+defmodule Fuschia.CidadeFactory do
+  @moduledoc false
+
+  defmacro __using__(_opts) do
+    quote do
+      alias Fuschia.Entities.Cidade
+
+      def cidade_factory do
+        %Cidade{
+          municipio: sequence(:municipio, &"Cidade #{&1}")
+        }
+      end
+    end
+  end
+end

--- a/test/support/factories/contato_factory.ex
+++ b/test/support/factories/contato_factory.ex
@@ -8,7 +8,7 @@ defmodule Fuschia.ContatoFactory do
       def contato_factory do
         %Contato{
           email: sequence(:email, &"test-#{&1}@example.com"),
-          celular: sequence(:celular, &"(11)98765432#{&1}"),
+          celular: sequence(:celular, ["(22)12345-6789"]),
           endereco: sequence(:endereco, &"Teste, Rua teste, número #{&1}")
         }
       end

--- a/test/support/factories/linha_pesquisa_factory.ex
+++ b/test/support/factories/linha_pesquisa_factory.ex
@@ -1,0 +1,18 @@
+defmodule Fuschia.LinhaPesquisaFactory do
+  @moduledoc false
+
+  defmacro __using__(_opts) do
+    quote do
+      alias Fuschia.Entities.LinhaPesquisa
+
+      def linha_pesquisa_factory do
+        %LinhaPesquisa{
+          numero: sequence(:numero, 1..21),
+          descricao_curta: sequence(:descricao_curta, &"Descricao LinhaPesquisa Curta #{&1}"),
+          descricao_longa: sequence(:descricao_longa, &"Descricao LinhaPesquisa Longa #{&1}"),
+          nucleo: build(:nucleo)
+        }
+      end
+    end
+  end
+end

--- a/test/support/factories/linha_pesquisa_factory.ex
+++ b/test/support/factories/linha_pesquisa_factory.ex
@@ -6,11 +6,13 @@ defmodule Fuschia.LinhaPesquisaFactory do
       alias Fuschia.Entities.LinhaPesquisa
 
       def linha_pesquisa_factory do
+        nucleo = insert(:nucleo)
+
         %LinhaPesquisa{
-          numero: sequence(:numero, 1..21),
+          numero: sequence(:numero, Enum.to_list(1..21)),
           descricao_curta: sequence(:descricao_curta, &"Descricao LinhaPesquisa Curta #{&1}"),
           descricao_longa: sequence(:descricao_longa, &"Descricao LinhaPesquisa Longa #{&1}"),
-          nucleo: build(:nucleo)
+          nucleo_nome: nucleo.nome
         }
       end
     end

--- a/test/support/factories/nucleo_factory.ex
+++ b/test/support/factories/nucleo_factory.ex
@@ -1,0 +1,17 @@
+defmodule Fuschia.NucleoFactory do
+  @moduledoc false
+
+  defmacro __using__(_opts) do
+    quote do
+      alias Fuschia.Entities.Nucleo
+
+      def nucleo_factory do
+        %Nucleo{
+          nome: sequence(:nome, &"Nucleo #{&1}"),
+          descricao: sequence(:descricao, &"Descricao Nucleo #{&1}"),
+          linhas_pesquisa: build_list(2, :linha_pesquisa)
+        }
+      end
+    end
+  end
+end

--- a/test/support/factories/nucleo_factory.ex
+++ b/test/support/factories/nucleo_factory.ex
@@ -8,8 +8,7 @@ defmodule Fuschia.NucleoFactory do
       def nucleo_factory do
         %Nucleo{
           nome: sequence(:nome, &"Nucleo #{&1}"),
-          descricao: sequence(:descricao, &"Descricao Nucleo #{&1}"),
-          linhas_pesquisa: build_list(2, :linha_pesquisa)
+          descricao: sequence(:descricao, &"Descricao Nucleo #{&1}")
         }
       end
     end

--- a/test/support/factories/universidade_factory.ex
+++ b/test/support/factories/universidade_factory.ex
@@ -1,0 +1,16 @@
+defmodule Fuschia.UniversidadeFactory do
+  @moduledoc false
+
+  defmacro __using__(_opts) do
+    quote do
+      alias Fuschia.Entities.Universidade
+
+      def universidade_factory do
+        %Universidade{
+          nome: sequence(:nome_completo, &"Universidade #{&1}"),
+          cidade: build(:cidade)
+        }
+      end
+    end
+  end
+end

--- a/test/support/factories/universidade_factory.ex
+++ b/test/support/factories/universidade_factory.ex
@@ -6,11 +6,9 @@ defmodule Fuschia.UniversidadeFactory do
       alias Fuschia.Entities.Universidade
 
       def universidade_factory do
-        %{municipio: cidade_municipio} = insert(:cidade)
-
         %Universidade{
           nome: sequence(:nome_completo, &"Universidade #{&1}"),
-          cidade_municipio: cidade_municipio
+          cidade: build(:cidade)
         }
       end
     end

--- a/test/support/factories/universidade_factory.ex
+++ b/test/support/factories/universidade_factory.ex
@@ -7,7 +7,7 @@ defmodule Fuschia.UniversidadeFactory do
 
       def universidade_factory do
         %Universidade{
-          nome: sequence(:nome_completo, &"Universidade #{&1}"),
+          nome: sequence(:nome, &"Universidade #{&1}"),
           cidade: build(:cidade)
         }
       end

--- a/test/support/factories/universidade_factory.ex
+++ b/test/support/factories/universidade_factory.ex
@@ -6,9 +6,11 @@ defmodule Fuschia.UniversidadeFactory do
       alias Fuschia.Entities.Universidade
 
       def universidade_factory do
+        %{municipio: cidade_municipio} = insert(:cidade)
+
         %Universidade{
           nome: sequence(:nome_completo, &"Universidade #{&1}"),
-          cidade: build(:cidade)
+          cidade_municipio: cidade_municipio
         }
       end
     end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -4,6 +4,8 @@ defmodule Fuschia.Factory do
   use ExMachina.Ecto, repo: Fuschia.Repo
 
   use Fuschia.AuthLogFactory
+  use Fuschia.CidadeFactory
   use Fuschia.ContatoFactory
   use Fuschia.UserFactory
+  use Fuschia.UniversidadeFactory
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -6,6 +6,8 @@ defmodule Fuschia.Factory do
   use Fuschia.AuthLogFactory
   use Fuschia.CidadeFactory
   use Fuschia.ContatoFactory
+  use Fuschia.LinhaPesquisaFactory
+  use Fuschia.NucleoFactory
   use Fuschia.UserFactory
   use Fuschia.UniversidadeFactory
 end


### PR DESCRIPTION
# Descrição
Implementa correções no mapeamento e implementa os respectivos contextos e testes autopmatizados para as seguintes entidades:
- Universidade
- Cidade
- Nucleo
- Linha Pesquisa


## Stories relacionadas (clubhouse)
- [ch-64]
- [ch-65]
- [ch-59]
- [ch-60]


## Pontos para atenção
Não há


## Possui novas configurações?
Não há


## Possui migrations?
Não há
