### PR TITLE
fix: remove duplicated `cast_assoc`

### DIFF
--- a/lib/fuschia/entities/user.ex
+++ b/lib/fuschia/entities/user.ex
@@ -73,7 +73,6 @@ defmodule Fuschia.Entities.User do
     |> validate_required([:password])
     |> validate_password()
     |> put_hashed_password()
-    |> cast_assoc(:contato, required: true)
   end
 
   @doc """
@@ -83,7 +82,6 @@ defmodule Fuschia.Entities.User do
     struct
     |> changeset(attrs)
     |> validate_required([:perfil])
-    |> cast_assoc(:contato, required: true)
   end
 
   @doc """


### PR DESCRIPTION
# Descrição
Remove a chamada duplicada do `cast_assoc/3` nos changesets de cadastro da entidade User


## Stories relacionadas (clubhouse)
- [ch-102]


## Pontos para atenção
N/A


## Possui novas configurações?
N/A


## Possui migrations?
N/A
