### PR TITLE
feat: use-cpf-to-login

### DIFF
--- a/lib/fuschia/context/users.ex
+++ b/lib/fuschia/context/users.ex
@@ -42,7 +42,7 @@ defmodule Fuschia.Context.Users do
       |> String.trim()
 
     query()
-    |> where([u], fragment("lower(?)", u.email) == ^email)
+    |> where([u, contato], fragment("lower(?)", contato.email) == ^email)
     |> where([u], u.ativo == true)
     |> order_by([u], desc: u.created_at)
     |> limit(1)

--- a/lib/fuschia/context/users.ex
+++ b/lib/fuschia/context/users.ex
@@ -42,7 +42,7 @@ defmodule Fuschia.Context.Users do
       |> String.trim()
 
     query()
-    |> where([u, contato], fragment("lower(?)", contato.email) == ^email)
+    |> where([u], fragment("lower(?)", u.email) == ^email)
     |> where([u], u.ativo == true)
     |> order_by([u], desc: u.created_at)
     |> limit(1)

--- a/lib/fuschia/context/users.ex
+++ b/lib/fuschia/context/users.ex
@@ -27,13 +27,22 @@ defmodule Fuschia.Context.Users do
 
   @spec one_by_cpf(String.t()) :: %User{} | nil
   def one_by_cpf(cpf) do
-    cpf =
-      cpf
+    cpf = String.trim(cpf)
+
+    query()
+    |> preload_all()
+    |> Repo.get_by(cpf: cpf)
+  end
+
+  @spec one_by_email(String.t()) :: %User{} | nil
+  def one_by_email(email) do
+    email =
+      email
       |> String.downcase()
       |> String.trim()
 
     query()
-    |> where([u, cpf], fragment("lower(?)", cpf) == ^cpf)
+    |> where([u, contato], fragment("lower(?)", contato.email) == ^email)
     |> where([u], u.ativo == true)
     |> order_by([u], desc: u.created_at)
     |> limit(1)

--- a/lib/fuschia/context/users.ex
+++ b/lib/fuschia/context/users.ex
@@ -25,15 +25,15 @@ defmodule Fuschia.Context.Users do
     |> put_is_admin()
   end
 
-  @spec one_by_email(String.t()) :: %User{} | nil
-  def one_by_email(email) do
-    email =
-      email
+  @spec one_by_cpf(String.t()) :: %User{} | nil
+  def one_by_cpf(cpf) do
+    cpf =
+      cpf
       |> String.downcase()
       |> String.trim()
 
     query()
-    |> where([u, contato], fragment("lower(?)", contato.email) == ^email)
+    |> where([u, cpf], fragment("lower(?)", cpf) == ^cpf)
     |> where([u], u.ativo == true)
     |> order_by([u], desc: u.created_at)
     |> limit(1)
@@ -42,9 +42,9 @@ defmodule Fuschia.Context.Users do
   end
 
   @spec one_with_permissions(String.t()) :: %User{} | nil
-  def one_with_permissions(email) do
-    email
-    |> one_by_email()
+  def one_with_permissions(cpf) do
+    cpf
+    |> one_by_cpf()
     |> put_permissions()
     |> put_is_admin()
   end

--- a/lib/fuschia_web/auth/guardian.ex
+++ b/lib/fuschia_web/auth/guardian.ex
@@ -15,26 +15,7 @@ defmodule FuschiaWeb.Auth.Guardian do
   end
 
   @spec resource_from_claims(map) ::
-          {:ok,
-           nil
-           | %Fuschia.Entities.User{
-               __meta__: any,
-               ativo: any,
-               confirmed: any,
-               contato: any,
-               contato_id: any,
-               cpf: any,
-               created_at: any,
-               data_nascimento: any,
-               is_admin: boolean,
-               last_seen: any,
-               nome_completo: any,
-               password: any,
-               password_hash: any,
-               perfil: any,
-               permissoes: nil,
-               updated_at: any
-             }}
+          {:error, nil} | {:ok, %User{}}
   def resource_from_claims(claims) do
     user =
       claims

--- a/lib/fuschia_web/auth/guardian.ex
+++ b/lib/fuschia_web/auth/guardian.ex
@@ -14,6 +14,27 @@ defmodule FuschiaWeb.Auth.Guardian do
     {:ok, sub}
   end
 
+  @spec resource_from_claims(map) ::
+          {:ok,
+           nil
+           | %Fuschia.Entities.User{
+               __meta__: any,
+               ativo: any,
+               confirmed: any,
+               contato: any,
+               contato_id: any,
+               cpf: any,
+               created_at: any,
+               data_nascimento: any,
+               is_admin: boolean,
+               last_seen: any,
+               nome_completo: any,
+               password: any,
+               password_hash: any,
+               perfil: any,
+               permissoes: nil,
+               updated_at: any
+             }}
   def resource_from_claims(claims) do
     user =
       claims
@@ -23,15 +44,15 @@ defmodule FuschiaWeb.Auth.Guardian do
     {:ok, user}
   end
 
-  def authenticate(%{"email" => email, "password" => password}) do
-    case Users.one_by_email(email) do
+  def authenticate(%{"cpf" => cpf, "password" => password}) do
+    case Users.one_by_cpf(cpf) do
       nil -> {:error, :unauthorized}
       user -> validate_password(user, password)
     end
   end
 
-  def user_claims(%{"email" => email}) do
-    case user = Users.one_with_permissions(email) do
+  def user_claims(%{"cpf" => cpf}) do
+    case user = Users.one_with_permissions(cpf) do
       nil -> {:error, :unauthorized}
       _ -> {:ok, User.for_jwt(user)}
     end

--- a/lib/fuschia_web/auth/guardian.ex
+++ b/lib/fuschia_web/auth/guardian.ex
@@ -14,8 +14,7 @@ defmodule FuschiaWeb.Auth.Guardian do
     {:ok, sub}
   end
 
-  @spec resource_from_claims(map) ::
-          {:error, nil} | {:ok, %User{}}
+  @spec resource_from_claims(map) :: {:ok, %User{}} | {:error, nil}
   def resource_from_claims(claims) do
     user =
       claims

--- a/lib/fuschia_web/swagger/schemas/auth.ex
+++ b/lib/fuschia_web/swagger/schemas/auth.ex
@@ -17,12 +17,12 @@ defmodule FuschiaWeb.Swagger.AuthSchemas do
       ],
       type: :object,
       properties: %{
-        email: %Schema{type: :string, description: "User Email"},
+        cpf: %Schema{type: :string, description: "User CPF"},
         password: %Schema{type: :string, description: "User Password", format: "password"}
       },
-      required: [:email, :password],
+      required: [:cpf, :password],
       example: %{
-        "email" => "admin.dev@example.com",
+        "cpf" => "123.456.789-12",
         "password" => "123456"
       }
     })
@@ -121,12 +121,12 @@ defmodule FuschiaWeb.Swagger.AuthSchemas do
       description: "POST body for user login",
       type: :object,
       properties: %{
-        email: %Schema{type: :string, description: "User E-mail"},
+        cpf: %Schema{type: :string, description: "User CPF"},
         password: %Schema{type: :string, description: "User Password", format: "password"}
       },
-      required: [:email, :password],
+      required: [:cpf, :password],
       example: %{
-        "email" => "admin.dev@example.com",
+        "cpf" => "123.456.789-12",
         "password" => "123456"
       }
     })

--- a/test/fuschia/context/users_test.exs
+++ b/test/fuschia/context/users_test.exs
@@ -32,6 +32,21 @@ defmodule Fuschia.Context.UsersTest do
     end
   end
 
+  describe "one_by_cpf/1" do
+    test "when CPF is valid, returns a user" do
+      user =
+        :user
+        |> insert()
+        |> Users.preload_all()
+
+      assert user == Users.one_by_cpf(user.cpf)
+    end
+
+    test "when CPF is invalid, return nil" do
+      assert is_nil(Users.one_by_cpf(""))
+    end
+  end
+
   describe "one_by_email/1" do
     test "when email is valid, returns a user" do
       user =

--- a/test/support/test_support.ex
+++ b/test/support/test_support.ex
@@ -13,7 +13,7 @@ defmodule CoreWeb.TestSupport do
   """
   @spec login(%Plug.Conn{}, %User{}) :: %Plug.Conn{}
   def login(conn, user) do
-    params = %{"email" => user.contato.email, "password" => user.password}
+    params = %{"cpf" => user.cpf, "password" => user.password}
 
     with {:ok, token} <- Guardian.authenticate(params),
          {:ok, _user} <- Guardian.user_claims(params) do


### PR DESCRIPTION

# Descrição
﻿O login via JSON agora utiliza o cpf do usuario ao inves do email.


## Stories relacionadas (clubhouse)
- [ch-101]


## Pontos para atenção
- Login usando o cpf do usuario.
- Erro na funcao lower.


## Possui novas configurações?
N/A

## Possui migrations?
N/A
