### PR TITLE
feat: add unique index for midia primery key

### DIFF
--- a/lib/fuschia/entities/midia.ex
+++ b/lib/fuschia/entities/midia.ex
@@ -34,6 +34,7 @@ defmodule Fuschia.Entites.Midia do
     struct
     |> cast(attrs, @required_fields)
     |> validate_required(@required_fields)
+    |> unique_constraint(:link)
     |> foreign_key_constraint(:pesquisador_cpf)
   end
 
@@ -42,8 +43,7 @@ defmodule Fuschia.Entites.Midia do
       %{
         tipo: struct.tipo,
         link: struct.link,
-        tags: struct.tags,
-        pesquisador_cpf: struct.pesquisador_cpf
+        tags: struct.tags
       }
       |> Fuschia.Encoder.encode(opts)
     end

--- a/priv/repo/migrations/20211203004312_create_midia.exs
+++ b/priv/repo/migrations/20211203004312_create_midia.exs
@@ -16,6 +16,7 @@ defmodule Fuschia.Repo.Migrations.CreateMidia do
           )
     end
 
-    create(index(:midia, [:pesquisador_cpf]))
+    create unique_index(:midia, [:link])
+    create index(:midia, [:pesquisador_cpf])
   end
 end


### PR DESCRIPTION
# Descrição
Adiciona um índice único para a chave primária da entidade `Midia`, `link`


## Stories relacionadas (Shortcut)
- [sc-xxxx]


## Pontos para atenção
N/A


## Possui novas configurações?
N/A


## Possui migrations?
N/A
