### PR TITLE
feature/strict credo issues

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -172,7 +172,7 @@
         {Credo.Check.Refactor.ABCSize, false},
         {Credo.Check.Refactor.AppendSingleItem, []},
         {Credo.Check.Refactor.DoubleBooleanNegation, []},
-        {Credo.Check.Refactor.ModuleDependencies, []},
+        {Credo.Check.Refactor.ModuleDependencies, false},
         {Credo.Check.Refactor.NegatedIsNil, []},
         {Credo.Check.Refactor.PipeChainStart, []},
         {Credo.Check.Refactor.VariableRebinding, false},

--- a/.credo.exs
+++ b/.credo.exs
@@ -1,0 +1,189 @@
+# This file contains the configuration for Credo and you are probably reading
+# this after creating it with `mix credo.gen.config`.
+#
+# If you find anything wrong or unclear in this file, please report an
+# issue on GitHub: https://github.com/rrrene/credo/issues
+#
+%{
+  #
+  # You can have as many configs as you like in the `configs:` field.
+  configs: [
+    %{
+      #
+      # Run any config using `mix credo -C <name>`. If no config name is given
+      # "default" is used.
+      #
+      name: "default",
+      #
+      # These are the files included in the analysis:
+      files: %{
+        #
+        # You can give explicit globs or simply directories.
+        # In the latter case `**/*.{ex,exs}` will be used.
+        #
+        included: [
+          "lib/",
+          "src/",
+          "test/",
+          "web/",
+          "apps/*/lib/",
+          "apps/*/src/",
+          "apps/*/test/",
+          "apps/*/web/"
+        ],
+        excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/"]
+      },
+      #
+      # Load and configure plugins here:
+      #
+      plugins: [],
+      #
+      # If you create your own checks, you must specify the source files for
+      # them here, so they can be loaded by Credo before running the analysis.
+      #
+      requires: [],
+      #
+      # If you want to enforce a style guide and need a more traditional linting
+      # experience, you can change `strict` to `true` below:
+      #
+      strict: true,
+      #
+      # To modify the timeout for parsing files, change this value:
+      #
+      parse_timeout: 5000,
+      #
+      # If you want to use uncolored output by default, you can change `color`
+      # to `false` below:
+      #
+      color: true,
+      #
+      # You can customize the parameters of any check by adding a second element
+      # to the tuple.
+      #
+      # To disable a check put `false` as second element:
+      #
+      #     {Credo.Check.Design.DuplicatedCode, false}
+      #
+      checks: [
+        #
+        ## Consistency Checks
+        #
+        {Credo.Check.Consistency.ExceptionNames, []},
+        {Credo.Check.Consistency.LineEndings, []},
+        {Credo.Check.Consistency.ParameterPatternMatching, []},
+        {Credo.Check.Consistency.SpaceAroundOperators, []},
+        {Credo.Check.Consistency.SpaceInParentheses, []},
+        {Credo.Check.Consistency.TabsOrSpaces, []},
+
+        #
+        ## Design Checks
+        #
+        # You can customize the priority of any check
+        # Priority values are: `low, normal, high, higher`
+        #
+        {Credo.Check.Design.AliasUsage,
+         [priority: :low, if_nested_deeper_than: 2, if_called_more_often_than: 0]},
+        # You can also customize the exit_status of each check.
+        # If you don't want TODO comments to cause `mix credo` to fail, just
+        # set this value to 0 (zero).
+        #
+        {Credo.Check.Design.TagTODO, [exit_status: 2]},
+        {Credo.Check.Design.TagFIXME, []},
+
+        #
+        ## Readability Checks
+        #
+        {Credo.Check.Readability.AliasOrder, []},
+        {Credo.Check.Readability.FunctionNames, []},
+        {Credo.Check.Readability.LargeNumbers, []},
+        {Credo.Check.Readability.MaxLineLength, [priority: :low, max_length: 120]},
+        {Credo.Check.Readability.ModuleAttributeNames, []},
+        {Credo.Check.Readability.ModuleDoc, []},
+        {Credo.Check.Readability.ModuleNames, []},
+        {Credo.Check.Readability.ParenthesesInCondition, []},
+        {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
+        {Credo.Check.Readability.PredicateFunctionNames, []},
+        {Credo.Check.Readability.PreferImplicitTry, []},
+        {Credo.Check.Readability.RedundantBlankLines, []},
+        {Credo.Check.Readability.Semicolons, []},
+        {Credo.Check.Readability.SpaceAfterCommas, []},
+        {Credo.Check.Readability.StringSigils, []},
+        {Credo.Check.Readability.TrailingBlankLine, []},
+        {Credo.Check.Readability.TrailingWhiteSpace, []},
+        {Credo.Check.Readability.UnnecessaryAliasExpansion, []},
+        {Credo.Check.Readability.VariableNames, []},
+
+        #
+        ## Refactoring Opportunities
+        #
+        {Credo.Check.Refactor.CondStatements, []},
+        {Credo.Check.Refactor.CyclomaticComplexity, []},
+        {Credo.Check.Refactor.FunctionArity, []},
+        {Credo.Check.Refactor.LongQuoteBlocks, []},
+        # {Credo.Check.Refactor.MapInto, []},
+        {Credo.Check.Refactor.MatchInCondition, []},
+        {Credo.Check.Refactor.NegatedConditionsInUnless, []},
+        {Credo.Check.Refactor.NegatedConditionsWithElse, []},
+        {Credo.Check.Refactor.Nesting, []},
+        {Credo.Check.Refactor.UnlessWithElse, []},
+        {Credo.Check.Refactor.WithClauses, []},
+
+        #
+        ## Warnings
+        #
+        {Credo.Check.Warning.ApplicationConfigInModuleAttribute, []},
+        {Credo.Check.Warning.BoolOperationOnSameValues, []},
+        {Credo.Check.Warning.ExpensiveEmptyEnumCheck, []},
+        {Credo.Check.Warning.IExPry, []},
+        {Credo.Check.Warning.IoInspect, []},
+        # {Credo.Check.Warning.LazyLogging, []},
+        {Credo.Check.Warning.MixEnv, false},
+        {Credo.Check.Warning.OperationOnSameValues, []},
+        {Credo.Check.Warning.OperationWithConstantResult, []},
+        {Credo.Check.Warning.RaiseInsideRescue, []},
+        {Credo.Check.Warning.UnusedEnumOperation, []},
+        {Credo.Check.Warning.UnusedFileOperation, []},
+        {Credo.Check.Warning.UnusedKeywordOperation, []},
+        {Credo.Check.Warning.UnusedListOperation, []},
+        {Credo.Check.Warning.UnusedPathOperation, []},
+        {Credo.Check.Warning.UnusedRegexOperation, []},
+        {Credo.Check.Warning.UnusedStringOperation, []},
+        {Credo.Check.Warning.UnusedTupleOperation, []},
+        {Credo.Check.Warning.UnsafeExec, []},
+
+        #
+        # Checks scheduled for next check update (opt-in for now, just replace `false` with `[]`)
+
+        #
+        # Controversial and experimental checks (opt-in, just replace `false` with `[]`)
+        #
+        {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
+        {Credo.Check.Consistency.UnusedVariableNames, []},
+        {Credo.Check.Design.DuplicatedCode, []},
+        {Credo.Check.Readability.AliasAs, false},
+        {Credo.Check.Readability.BlockPipe, false},
+        {Credo.Check.Readability.ImplTrue, []},
+        {Credo.Check.Readability.MultiAlias, false},
+        {Credo.Check.Readability.SeparateAliasRequire, false},
+        {Credo.Check.Readability.SinglePipe, []},
+        {Credo.Check.Readability.Specs, []},
+        {Credo.Check.Readability.StrictModuleLayout, false},
+        {Credo.Check.Readability.WithCustomTaggedTuple, false},
+        {Credo.Check.Refactor.ABCSize, false},
+        {Credo.Check.Refactor.AppendSingleItem, []},
+        {Credo.Check.Refactor.DoubleBooleanNegation, []},
+        {Credo.Check.Refactor.ModuleDependencies, []},
+        {Credo.Check.Refactor.NegatedIsNil, []},
+        {Credo.Check.Refactor.PipeChainStart, []},
+        {Credo.Check.Refactor.VariableRebinding, false},
+        {Credo.Check.Warning.LeakyEnvironment, false},
+        {Credo.Check.Warning.MapGetUnsafePass, false},
+        {Credo.Check.Warning.UnsafeToAtom, false}
+
+        #
+        # Custom checks can be created using `mix credo.gen.check`.
+        #
+      ]
+    }
+  ]
+}

--- a/lib/fuschia/application.ex
+++ b/lib/fuschia/application.ex
@@ -32,7 +32,9 @@ defmodule Fuschia.Application do
     ]
 
     start_oban? =
-      Application.get_env(:fuschia, :jobs)[:start]
+      :fuschia
+      |> Application.get_env(:jobs)
+      |> Keyword.get(:start)
       |> Fuschia.Parser.to_boolean()
 
     if start_oban? do

--- a/lib/fuschia/application.ex
+++ b/lib/fuschia/application.ex
@@ -5,6 +5,7 @@ defmodule Fuschia.Application do
 
   use Application
 
+  @spec start(any, list) :: {:ok, pid} | {:error, any}
   def start(_type, _args) do
     opts = [strategy: :one_for_one, name: Fuschia.Supervisor]
 
@@ -13,6 +14,7 @@ defmodule Fuschia.Application do
 
   # Tell Phoenix to update the endpoint configuration
   # whenever the application is updated.
+  @spec config_change(keyword, keyword, keyword) :: :ok
   def config_change(changed, _new, removed) do
     FuschiaWeb.Endpoint.config_change(changed, removed)
     :ok

--- a/lib/fuschia/application.ex
+++ b/lib/fuschia/application.ex
@@ -38,7 +38,7 @@ defmodule Fuschia.Application do
       |> Fuschia.Parser.to_boolean()
 
     if start_oban? do
-      base_children ++ [{Oban, Application.get_env(:fuschia, Oban)}]
+      [{Oban, Application.get_env(:fuschia, Oban)} | base_children]
     else
       base_children
     end

--- a/lib/fuschia/common/formats.ex
+++ b/lib/fuschia/common/formats.ex
@@ -8,8 +8,12 @@ defmodule Fuschia.Common.Formats do
   @rg_format ~r/^\d{2}\.\d{3}\.\d{3}\-\d{1}$/
   @mobile_format ~r/^\(\d{2}\)(\d{5}|\s\d{5})-\d{4}$/
 
+  @spec cpf :: Regex.t()
   def cpf, do: @cpf_format
+  @spec rg :: Regex.t()
   def rg, do: @rg_format
+  @spec cnpj :: Regex.t()
   def cnpj, do: @cnpj_format
+  @spec mobile :: Regex.t()
   def mobile, do: @mobile_format
 end

--- a/lib/fuschia/context/api_keys.ex
+++ b/lib/fuschia/context/api_keys.ex
@@ -10,14 +10,12 @@ defmodule Fuschia.Context.ApiKeys do
 
   @spec one :: %ApiKey{}
   def one do
-    query()
-    |> Repo.one()
+    Repo.one(query())
   end
 
   @spec one_by_key(String.t()) :: %ApiKey{} | nil
   def one_by_key(key) do
-    query()
-    |> Repo.get_by(key: key)
+    Repo.get_by(query(), key: key)
   end
 
   @spec query :: Ecto.Query.t()

--- a/lib/fuschia/context/campi.ex
+++ b/lib/fuschia/context/campi.ex
@@ -70,13 +70,11 @@ defmodule Fuschia.Context.Campi do
 
   @spec preload_all(%Ecto.Query{}) :: %Ecto.Query{}
   def preload_all(%Ecto.Query{} = query) do
-    query
-    |> Ecto.Query.preload([:pesquisadores, cidade: [:campi]])
+    Ecto.Query.preload(query, [:pesquisadores, cidade: [:campi]])
   end
 
   @spec preload_all(%Campus{}) :: %Campus{}
   def preload_all(%Campus{} = campus) do
-    campus
-    |> Repo.preload([:pesquisadores, cidade: [:campi]])
+    Repo.preload(campus, [:pesquisadores, cidade: [:campi]])
   end
 end

--- a/lib/fuschia/context/cidades.ex
+++ b/lib/fuschia/context/cidades.ex
@@ -51,13 +51,11 @@ defmodule Fuschia.Context.Cidades do
 
   @spec preload_all(%Ecto.Query{}) :: %Ecto.Query{}
   def preload_all(%Ecto.Query{} = query) do
-    query
-    |> Ecto.Query.preload([:campi])
+    Ecto.Query.preload(query, [:campi])
   end
 
   @spec preload_all(%Cidade{}) :: %Cidade{}
   def preload_all(%Cidade{} = cidade) do
-    cidade
-    |> Repo.preload([:campi])
+    Repo.preload(cidade, [:campi])
   end
 end

--- a/lib/fuschia/context/linhas_pesquisas.ex
+++ b/lib/fuschia/context/linhas_pesquisas.ex
@@ -60,13 +60,11 @@ defmodule Fuschia.Context.LinhasPesquisas do
 
   @spec preload_all(%Ecto.Query{}) :: %Ecto.Query{}
   def preload_all(%Ecto.Query{} = query) do
-    query
-    |> Ecto.Query.preload(nucleo: [:linhas_pesquisa])
+    Ecto.Query.preload(query, nucleo: [:linhas_pesquisa])
   end
 
   @spec preload_all(%LinhaPesquisa{}) :: %LinhaPesquisa{}
   def preload_all(%LinhaPesquisa{} = linha_pesquisa) do
-    linha_pesquisa
-    |> Repo.preload(nucleo: [:linhas_pesquisa])
+    Repo.preload(linha_pesquisa, nucleo: [:linhas_pesquisa])
   end
 end

--- a/lib/fuschia/context/nucleos.ex
+++ b/lib/fuschia/context/nucleos.ex
@@ -51,13 +51,11 @@ defmodule Fuschia.Context.Nucleos do
 
   @spec preload_all(%Ecto.Query{}) :: %Ecto.Query{}
   def preload_all(%Ecto.Query{} = query) do
-    query
-    |> Ecto.Query.preload([:linhas_pesquisa])
+    Ecto.Query.preload(query, [:linhas_pesquisa])
   end
 
   @spec preload_all(%Nucleo{}) :: %Nucleo{}
   def preload_all(%Nucleo{} = nucleo) do
-    nucleo
-    |> Repo.preload([:linhas_pesquisa])
+    Repo.preload(nucleo, [:linhas_pesquisa])
   end
 end

--- a/lib/fuschia/context/pesquisadores.ex
+++ b/lib/fuschia/context/pesquisadores.ex
@@ -87,8 +87,8 @@ defmodule Fuschia.Context.Pesquisadores do
 
   @spec preload_all(%Ecto.Query{}) :: %Ecto.Query{}
   def preload_all(%Ecto.Query{} = query) do
-    query
-    |> Ecto.Query.preload(
+    Ecto.Query.preload(
+      query,
       orientador: [usuario: :contato],
       orientandos: [usuario: :contato],
       usuario: :contato,
@@ -98,8 +98,8 @@ defmodule Fuschia.Context.Pesquisadores do
 
   @spec preload_all(%Pesquisador{}) :: %Pesquisador{}
   def preload_all(%Pesquisador{} = pesquisador) do
-    pesquisador
-    |> Repo.preload(
+    Repo.preload(
+      pesquisador,
       orientador: [usuario: :contato],
       orientandos: [usuario: :contato],
       usuario: :contato,

--- a/lib/fuschia/context/pesquisadores.ex
+++ b/lib/fuschia/context/pesquisadores.ex
@@ -46,8 +46,18 @@ defmodule Fuschia.Context.Pesquisadores do
   def update(usuario_cpf, attrs) do
     attrs
     |> Parser.stringfy_map()
+    |> Map.put_new("usuario", nil)
     |> case do
-      %{"usuario" => usuario_attrs} = attrs when not is_nil(usuario_attrs) ->
+      %{"usuario" => nil} ->
+        with %Pesquisador{} = pesquisador <- one(usuario_cpf),
+             {:ok, updated} <-
+               pesquisador
+               |> Pesquisador.changeset(attrs)
+               |> Repo.update() do
+          {:ok, preload_all(updated)}
+        end
+
+      %{"usuario" => usuario_attrs} ->
         with %User{} = _user <- Users.one(usuario_cpf),
              %Ecto.Changeset{valid?: true} = usuario_changeset <-
                User.changeset(%User{}, usuario_attrs),
@@ -57,15 +67,6 @@ defmodule Fuschia.Context.Pesquisadores do
                |> then(&Pesquisador.update_changeset(%Pesquisador{}, &1))
                |> Repo.insert(on_conflict: :nothing) do
           {:ok, preload_all(pesquisador)}
-        end
-
-      _ ->
-        with %Pesquisador{} = pesquisador <- one(usuario_cpf),
-             {:ok, updated} <-
-               pesquisador
-               |> Pesquisador.changeset(attrs)
-               |> Repo.update() do
-          {:ok, preload_all(updated)}
         end
     end
   end

--- a/lib/fuschia/context/user_tokens.ex
+++ b/lib/fuschia/context/user_tokens.ex
@@ -7,6 +7,8 @@ defmodule Fuschia.Context.UserTokens do
 
   alias Fuschia.Entities.UserToken
 
+  @type user :: %Fuschia.Entities.User{}
+
   @hash_algorithm :sha256
 
   # It is very important to keep the reset password token expiry short,
@@ -20,6 +22,7 @@ defmodule Fuschia.Context.UserTokens do
 
   The query returns the user found by the token.
   """
+  @spec verify_email_token_query(String.t(), String.t()) :: {:ok, Ecto.Query.t()} | :error
   def verify_email_token_query(token, context) do
     case Base.url_decode64(token, padding: false) do
       {:ok, decoded_token} ->
@@ -48,6 +51,7 @@ defmodule Fuschia.Context.UserTokens do
 
   The query returns the user token record.
   """
+  @spec verify_change_email_token_query(String.t(), String.t()) :: {:ok, Ecto.Query.t()} | :error
   def verify_change_email_token_query(token, context) do
     case Base.url_decode64(token, padding: false) do
       {:ok, decoded_token} ->
@@ -67,6 +71,7 @@ defmodule Fuschia.Context.UserTokens do
   @doc """
   Returns the given token with the given context.
   """
+  @spec token_and_context_query(String.t(), String.t()) :: Ecto.Query.t()
   def token_and_context_query(token, context) do
     from UserToken, where: [token: ^token, context: ^context]
   end
@@ -74,6 +79,7 @@ defmodule Fuschia.Context.UserTokens do
   @doc """
   Gets all tokens for the given user for the given contexts.
   """
+  @spec user_and_contexts_query(user, list | :all) :: Ecto.Query.t()
   def user_and_contexts_query(user, :all) do
     from t in UserToken, where: t.user_cpf == ^user.cpf
   end

--- a/lib/fuschia/context/users.ex
+++ b/lib/fuschia/context/users.ex
@@ -149,7 +149,7 @@ defmodule Fuschia.Context.Users do
          {:ok, %{user: user}} <- Repo.transaction(confirm_multi(user)) do
       {:ok, user}
     else
-      _ -> :error
+      _err -> :error
     end
   end
 
@@ -168,7 +168,7 @@ defmodule Fuschia.Context.Users do
          {:ok, _} <- Repo.transaction(email_multi(user, email, context)) do
       :ok
     else
-      _ -> :error
+      _err -> :error
     end
   end
 

--- a/lib/fuschia/context/users.ex
+++ b/lib/fuschia/context/users.ex
@@ -219,14 +219,12 @@ defmodule Fuschia.Context.Users do
 
   @spec preload_all(%Ecto.Query{}) :: %Ecto.Query{}
   def preload_all(%Ecto.Query{} = query) do
-    query
-    |> Ecto.Query.preload([:contato])
+    Ecto.Query.preload(query, [:contato])
   end
 
   @spec preload_all(%User{}) :: %User{}
   def preload_all(%User{} = user) do
-    user
-    |> Repo.preload([:contato])
+    Repo.preload(user, [:contato])
   end
 
   defp put_is_admin(%User{perfil: "admin"} = user) do

--- a/lib/fuschia/encoder.ex
+++ b/lib/fuschia/encoder.ex
@@ -3,6 +3,7 @@ defmodule Fuschia.Encoder do
   Fuschia Custom JSON Encoder
   """
 
+  @spec encode(map, any) :: map
   def encode(attrs, opts) do
     attrs
     |> remove_not_loaded()
@@ -10,6 +11,7 @@ defmodule Fuschia.Encoder do
     |> Jason.Encode.map(opts)
   end
 
+  @spec remove_not_loaded(map) :: map
   def remove_not_loaded(attrs) do
     not_loaded = Enum.filter(attrs, &not_loaded?/1)
 

--- a/lib/fuschia/encoder.ex
+++ b/lib/fuschia/encoder.ex
@@ -11,9 +11,7 @@ defmodule Fuschia.Encoder do
   end
 
   def remove_not_loaded(attrs) do
-    not_loaded =
-      attrs
-      |> Enum.filter(&not_loaded?/1)
+    not_loaded = Enum.filter(attrs, &not_loaded?/1)
 
     Map.drop(attrs, Keyword.keys(not_loaded))
   end

--- a/lib/fuschia/entities/auth_log.ex
+++ b/lib/fuschia/entities/auth_log.ex
@@ -22,6 +22,7 @@ defmodule Fuschia.Entities.AuthLog do
     timestamps(updated_at: false)
   end
 
+  @spec changeset(%__MODULE__{}, map) :: Ecto.Changeset.t()
   def changeset(%__MODULE__{} = struct, attrs) do
     struct
     |> cast(attrs, @required_fields)

--- a/lib/fuschia/entities/campus.ex
+++ b/lib/fuschia/entities/campus.ex
@@ -42,12 +42,14 @@ defmodule Fuschia.Entities.Campus do
 
   defimpl Jason.Encoder, for: __MODULE__ do
     def encode(struct, opts) do
-      %{
-        nome: struct.nome,
-        cidade: struct.cidade,
-        pesquisadores: struct.pesquisadores
-      }
-      |> Fuschia.Encoder.encode(opts)
+      Fuschia.Encoder.encode(
+        %{
+          nome: struct.nome,
+          cidade: struct.cidade,
+          pesquisadores: struct.pesquisadores
+        },
+        opts
+      )
     end
   end
 end

--- a/lib/fuschia/entities/campus.ex
+++ b/lib/fuschia/entities/campus.ex
@@ -24,6 +24,7 @@ defmodule Fuschia.Entities.Campus do
     timestamps()
   end
 
+  @spec changeset(%__MODULE__{}, map) :: Ecto.Changeset.t()
   def changeset(%__MODULE__{} = struct, attrs) do
     struct
     |> cast(attrs, @required_fields)
@@ -32,6 +33,7 @@ defmodule Fuschia.Entities.Campus do
     |> cast_assoc(:cidade, required: true)
   end
 
+  @spec foreign_changeset(%__MODULE__{}, map) :: Ecto.Changeset.t()
   def foreign_changeset(%__MODULE__{} = struct, attrs) do
     struct
     |> cast(attrs, [:cidade_municipio | @required_fields])
@@ -41,6 +43,7 @@ defmodule Fuschia.Entities.Campus do
   end
 
   defimpl Jason.Encoder, for: __MODULE__ do
+    @spec encode(%Fuschia.Entities.Campus{}, map) :: map
     def encode(struct, opts) do
       Fuschia.Encoder.encode(
         %{

--- a/lib/fuschia/entities/cidade.ex
+++ b/lib/fuschia/entities/cidade.ex
@@ -18,6 +18,7 @@ defmodule Fuschia.Entities.Cidade do
     timestamps()
   end
 
+  @spec changeset(%__MODULE__{}, map) :: Ecto.Changeset.t()
   def changeset(%__MODULE__{} = struct, attrs) do
     struct
     |> cast(attrs, @required_fields)
@@ -26,6 +27,7 @@ defmodule Fuschia.Entities.Cidade do
   end
 
   defimpl Jason.Encoder, for: __MODULE__ do
+    @spec encode(%Fuschia.Entities.Cidade{}, map) :: map
     def encode(struct, opts) do
       Fuschia.Encoder.encode(
         %{

--- a/lib/fuschia/entities/cidade.ex
+++ b/lib/fuschia/entities/cidade.ex
@@ -27,11 +27,13 @@ defmodule Fuschia.Entities.Cidade do
 
   defimpl Jason.Encoder, for: __MODULE__ do
     def encode(struct, opts) do
-      %{
-        municipio: struct.municipio,
-        campi: struct.campi
-      }
-      |> Fuschia.Encoder.encode(opts)
+      Fuschia.Encoder.encode(
+        %{
+          municipio: struct.municipio,
+          campi: struct.campi
+        },
+        opts
+      )
     end
   end
 end

--- a/lib/fuschia/entities/contato.ex
+++ b/lib/fuschia/entities/contato.ex
@@ -53,13 +53,15 @@ defmodule Fuschia.Entities.Contato do
 
   defimpl Jason.Encoder, for: __MODULE__ do
     def encode(struct, opts) do
-      %{
-        id: struct.id,
-        celular: struct.celular,
-        email: struct.email,
-        endereco: struct.endereco
-      }
-      |> Fuschia.Encoder.encode(opts)
+      Fuschia.Encoder.encode(
+        %{
+          id: struct.id,
+          celular: struct.celular,
+          email: struct.email,
+          endereco: struct.endereco
+        },
+        opts
+      )
     end
   end
 end

--- a/lib/fuschia/entities/contato.ex
+++ b/lib/fuschia/entities/contato.ex
@@ -22,6 +22,7 @@ defmodule Fuschia.Entities.Contato do
   end
 
   @doc false
+  @spec changeset(%__MODULE__{}, map) :: Ecto.Changeset.t()
   def changeset(contato, attrs) do
     contato
     |> cast(attrs, @required_fields)
@@ -35,6 +36,7 @@ defmodule Fuschia.Entities.Contato do
 
   It requires the email to change otherwise an error is added.
   """
+  @spec email_changeset(%__MODULE__{}, map) :: Ecto.Changeset.t()
   def email_changeset(contact, attrs) do
     contact
     |> cast(attrs, [:email])
@@ -45,6 +47,7 @@ defmodule Fuschia.Entities.Contato do
     end
   end
 
+  @spec validate_email(Ecto.Changeset.t()) :: Ecto.Changeset.t()
   defp validate_email(changeset) do
     changeset
     |> validate_length(:email, max: 160)
@@ -52,6 +55,7 @@ defmodule Fuschia.Entities.Contato do
   end
 
   defimpl Jason.Encoder, for: __MODULE__ do
+    @spec encode(%Fuschia.Entities.Contato{}, map) :: map
     def encode(struct, opts) do
       Fuschia.Encoder.encode(
         %{

--- a/lib/fuschia/entities/linha_pesquisa.ex
+++ b/lib/fuschia/entities/linha_pesquisa.ex
@@ -25,6 +25,7 @@ defmodule Fuschia.Entities.LinhaPesquisa do
   end
 
   @doc false
+  @spec changeset(%__MODULE__{}, map) :: Ecto.Changeset.t()
   def changeset(%__MODULE__{} = struct, attrs) do
     struct
     |> cast(attrs, @required_fields ++ @optional_fields)
@@ -35,6 +36,7 @@ defmodule Fuschia.Entities.LinhaPesquisa do
   end
 
   defimpl Jason.Encoder, for: __MODULE__ do
+    @spec encode(%Fuschia.Entities.LinhaPesquisa{}, map) :: map
     def encode(struct, opts) do
       Fuschia.Encoder.encode(
         %{

--- a/lib/fuschia/entities/linha_pesquisa.ex
+++ b/lib/fuschia/entities/linha_pesquisa.ex
@@ -36,13 +36,15 @@ defmodule Fuschia.Entities.LinhaPesquisa do
 
   defimpl Jason.Encoder, for: __MODULE__ do
     def encode(struct, opts) do
-      %{
-        descricao_curta: struct.descricao_curta,
-        descricao_longa: struct.descricao_longa,
-        numero: struct.numero,
-        nucleo: struct.nucleo
-      }
-      |> Fuschia.Encoder.encode(opts)
+      Fuschia.Encoder.encode(
+        %{
+          descricao_curta: struct.descricao_curta,
+          descricao_longa: struct.descricao_longa,
+          numero: struct.numero,
+          nucleo: struct.nucleo
+        },
+        opts
+      )
     end
   end
 end

--- a/lib/fuschia/entities/midia.ex
+++ b/lib/fuschia/entities/midia.ex
@@ -30,6 +30,7 @@ defmodule Fuschia.Entites.Midia do
     timestamps()
   end
 
+  @spec changeset(%__MODULE__{}, map) :: Ecto.Changeset.t()
   def changeset(%__MODULE__{} = struct, attrs) do
     struct
     |> cast(attrs, @required_fields)
@@ -39,6 +40,7 @@ defmodule Fuschia.Entites.Midia do
   end
 
   defimpl Jason.Encoder, for: __MODULE__ do
+    @spec encode(%Fuschia.Entites.Midia{}, map) :: map
     def encode(struct, opts) do
       Fuschia.Encoder.encode(
         %{

--- a/lib/fuschia/entities/midia.ex
+++ b/lib/fuschia/entities/midia.ex
@@ -40,12 +40,14 @@ defmodule Fuschia.Entites.Midia do
 
   defimpl Jason.Encoder, for: __MODULE__ do
     def encode(struct, opts) do
-      %{
-        tipo: struct.tipo,
-        link: struct.link,
-        tags: struct.tags
-      }
-      |> Fuschia.Encoder.encode(opts)
+      Fuschia.Encoder.encode(
+        %{
+          tipo: struct.tipo,
+          link: struct.link,
+          tags: struct.tags
+        },
+        opts
+      )
     end
   end
 end

--- a/lib/fuschia/entities/nucleo.ex
+++ b/lib/fuschia/entities/nucleo.ex
@@ -29,12 +29,14 @@ defmodule Fuschia.Entities.Nucleo do
 
   defimpl Jason.Encoder, for: __MODULE__ do
     def encode(struct, opts) do
-      %{
-        nome: struct.nome,
-        descricao: struct.descricao,
-        linhas_pesquisa: struct.linhas_pesquisa
-      }
-      |> Fuschia.Encoder.encode(opts)
+      Fuschia.Encoder.encode(
+        %{
+          nome: struct.nome,
+          descricao: struct.descricao,
+          linhas_pesquisa: struct.linhas_pesquisa
+        },
+        opts
+      )
     end
   end
 end

--- a/lib/fuschia/entities/nucleo.ex
+++ b/lib/fuschia/entities/nucleo.ex
@@ -20,6 +20,7 @@ defmodule Fuschia.Entities.Nucleo do
   end
 
   @doc false
+  @spec changeset(%__MODULE__{}, map) :: Ecto.Changeset.t()
   def changeset(%__MODULE__{} = struct, attrs) do
     struct
     |> cast(attrs, @required_fields)
@@ -28,6 +29,7 @@ defmodule Fuschia.Entities.Nucleo do
   end
 
   defimpl Jason.Encoder, for: __MODULE__ do
+    @spec encode(%Fuschia.Entities.Nucleo{}, map) :: map
     def encode(struct, opts) do
       Fuschia.Encoder.encode(
         %{

--- a/lib/fuschia/entities/pesquisador.ex
+++ b/lib/fuschia/entities/pesquisador.ex
@@ -53,6 +53,7 @@ defmodule Fuschia.Entities.Pesquisador do
   end
 
   @doc false
+  @spec changeset(%__MODULE__{}, map) :: Ecto.Changeset.t()
   def changeset(%__MODULE__{} = struct, attrs) do
     struct
     |> cast(attrs, @required_fields ++ @optional_fields)
@@ -64,6 +65,7 @@ defmodule Fuschia.Entities.Pesquisador do
     |> foreign_key_constraint(:campus_nome)
   end
 
+  @spec update_changeset(%__MODULE__{}, map) :: Ecto.Changeset.t()
   def update_changeset(%__MODULE__{} = struct, attrs) do
     struct
     |> cast(attrs, @required_fields ++ @optional_fields)
@@ -76,6 +78,7 @@ defmodule Fuschia.Entities.Pesquisador do
   end
 
   defimpl Jason.Encoder, for: __MODULE__ do
+    @spec encode(%Fuschia.Entities.Pesquisador{}, map) :: map
     def encode(struct, opts) do
       Fuschia.Encoder.encode(
         %{

--- a/lib/fuschia/entities/pesquisador.ex
+++ b/lib/fuschia/entities/pesquisador.ex
@@ -77,17 +77,19 @@ defmodule Fuschia.Entities.Pesquisador do
 
   defimpl Jason.Encoder, for: __MODULE__ do
     def encode(struct, opts) do
-      %{
-        cpf: struct.cpf,
-        minibiografia: struct.minibibliografia,
-        tipo_bolsa: struct.tipo_bolsa,
-        link_lattes: struct.link_lattes,
-        orientador: struct.orientador,
-        campus: struct.campus,
-        usuario: struct.usuario,
-        orientandos: struct.orientandos
-      }
-      |> Fuschia.Encoder.encode(opts)
+      Fuschia.Encoder.encode(
+        %{
+          cpf: struct.cpf,
+          minibiografia: struct.minibibliografia,
+          tipo_bolsa: struct.tipo_bolsa,
+          link_lattes: struct.link_lattes,
+          orientador: struct.orientador,
+          campus: struct.campus,
+          usuario: struct.usuario,
+          orientandos: struct.orientandos
+        },
+        opts
+      )
     end
   end
 end

--- a/lib/fuschia/entities/relatorio.ex
+++ b/lib/fuschia/entities/relatorio.ex
@@ -36,6 +36,17 @@ defmodule Fuschia.Entities.Relatorio do
     timestamps()
   end
 
+  @spec changeset(%__MODULE__{}, map) :: Ecto.Changeset.t()
+  def changeset(%__MODULE__{} = struct, attrs) do
+    struct
+    |> cast(attrs, @required_fields)
+    |> validate_required(@required_fields)
+    |> validate_month(:mes)
+    |> validate_year(:ano)
+    |> validate_inclusion(:tipo, @tipos)
+    |> foreign_key_constraint(:pesquisador_cpf)
+  end
+
   defp validate_month(changeset, field) do
     month = 1..12
 
@@ -60,26 +71,19 @@ defmodule Fuschia.Entities.Relatorio do
     end
   end
 
-  def changeset(%__MODULE__{} = struct, attrs) do
-    struct
-    |> cast(attrs, @required_fields)
-    |> validate_required(@required_fields)
-    |> validate_month(:mes)
-    |> validate_year(:ano)
-    |> validate_inclusion(:tipo, @tipos)
-    |> foreign_key_constraint(:pesquisador_cpf)
-  end
-
   defimpl Jason.Encoder, for: __MODULE__ do
+    @spec encode(Fuschia.Entities.Relatorio.t(), map) :: map
     def encode(struct, opts) do
-      %{
-        ano: struct.ano,
-        mes: struct.mes,
-        tipo: struct.tipo,
-        link: struct.link,
-        pesquisador_cpf: struct.pesquisador_cpf
-      }
-      |> Fuschia.Encoder.encode(opts)
+      Fuschia.Encoder.encode(
+        %{
+          ano: struct.ano,
+          mes: struct.mes,
+          tipo: struct.tipo,
+          link: struct.link,
+          pesquisador_cpf: struct.pesquisador_cpf
+        },
+        opts
+      )
     end
   end
 end

--- a/lib/fuschia/entities/user.ex
+++ b/lib/fuschia/entities/user.ex
@@ -126,7 +126,7 @@ defmodule Fuschia.Entities.User do
     Bcrypt.verify_pass(password, hashed_password)
   end
 
-  def valid_password?(_, _) do
+  def valid_password?(_invalid_hash, _invalid_password) do
     Bcrypt.no_user_verify()
     false
   end
@@ -158,7 +158,7 @@ defmodule Fuschia.Entities.User do
       %Ecto.Changeset{valid?: true, changes: %{password: password}} ->
         put_change(changeset, :password_hash, Bcrypt.hash_pwd_salt(password))
 
-      _ ->
+      _no_password ->
         changeset
     end
   end

--- a/lib/fuschia/entities/user.ex
+++ b/lib/fuschia/entities/user.ex
@@ -165,15 +165,17 @@ defmodule Fuschia.Entities.User do
 
   defimpl Jason.Encoder, for: User do
     def encode(struct, opts) do
-      %{
-        nome_completo: struct.nome_completo,
-        perfil: struct.perfil,
-        ultimo_login: struct.last_seen,
-        confirmado: struct.confirmed,
-        ativo: struct.ativo,
-        data_nascimento: struct.data_nascimento
-      }
-      |> Fuschia.Encoder.encode(opts)
+      Fuschia.Encoder.encode(
+        %{
+          nome_completo: struct.nome_completo,
+          perfil: struct.perfil,
+          ultimo_login: struct.last_seen,
+          confirmado: struct.confirmed,
+          ativo: struct.ativo,
+          data_nascimento: struct.data_nascimento
+        },
+        opts
+      )
     end
   end
 end

--- a/lib/fuschia/entities/user.ex
+++ b/lib/fuschia/entities/user.ex
@@ -40,6 +40,7 @@ defmodule Fuschia.Entities.User do
     timestamps()
   end
 
+  @spec changeset(%__MODULE__{}, map) :: Ecto.Changeset.t()
   def changeset(%__MODULE__{} = struct, attrs) do
     struct
     |> cast(attrs, @required_fields ++ @optional_fields)
@@ -52,6 +53,7 @@ defmodule Fuschia.Entities.User do
     |> foreign_key_constraint(:cpf, name: :pesquisador_usuario_cpf_fkey)
   end
 
+  @spec update_changeset(%__MODULE__{}, map) :: Ecto.Changeset.t()
   def update_changeset(%__MODULE__{} = struct, attrs) do
     struct
     |> cast(attrs, @required_fields ++ @optional_fields)
@@ -65,6 +67,7 @@ defmodule Fuschia.Entities.User do
   @doc """
   Changeset for user signup
   """
+  @spec registration_changeset(%__MODULE__{}, map) :: Ecto.Changeset.t()
   def registration_changeset(%__MODULE__{} = struct, attrs) do
     struct
     |> changeset(attrs)
@@ -78,6 +81,7 @@ defmodule Fuschia.Entities.User do
   @doc """
   Changeset for users created on admin
   """
+  @spec admin_changeset(%__MODULE__{}, map) :: Ecto.Changeset.t()
   def admin_changeset(%__MODULE__{} = struct, attrs) do
     struct
     |> changeset(attrs)
@@ -87,6 +91,7 @@ defmodule Fuschia.Entities.User do
   @doc """
   A user changeset for changing the password.
   """
+  @spec password_changeset(%__MODULE__{}, map) :: Ecto.Changeset.t()
   def password_changeset(user, attrs) do
     user
     |> cast(attrs, [:password])
@@ -98,10 +103,12 @@ defmodule Fuschia.Entities.User do
   @doc """
   Confirms the account by setting `confirmed`.
   """
+  @spec confirm_changeset(%__MODULE__{}) :: Ecto.Changeset.t()
   def confirm_changeset(user) do
     change(user, confirmed: true)
   end
 
+  @spec for_jwt(%__MODULE__{}) :: map
   def for_jwt(%__MODULE__{} = struct) do
     %{
       email: struct.contato.email,
@@ -121,6 +128,7 @@ defmodule Fuschia.Entities.User do
   If there is no usuario or the usuario doesn't have a password, we call
   `Bcrypt.no_user_verify/0` to avoid timing attacks.
   """
+  @spec valid_password?(%__MODULE__{}, String.t()) :: bool
   def valid_password?(%User{password_hash: hashed_password}, password)
       when is_binary(hashed_password) and byte_size(password) > 0 do
     Bcrypt.verify_pass(password, hashed_password)
@@ -134,6 +142,7 @@ defmodule Fuschia.Entities.User do
   @doc """
   Validates the current password otherwise adds an error to the changeset.
   """
+  @spec validate_current_password(Ecto.Changeset.t(), String.t()) :: Ecto.Changeset.t()
   def validate_current_password(changeset, password) do
     if valid_password?(changeset.data, password) do
       changeset
@@ -164,6 +173,7 @@ defmodule Fuschia.Entities.User do
   end
 
   defimpl Jason.Encoder, for: User do
+    @spec encode(%Fuschia.Entities.User{}, map) :: map
     def encode(struct, opts) do
       Fuschia.Encoder.encode(
         %{

--- a/lib/fuschia/entities/user_token.ex
+++ b/lib/fuschia/entities/user_token.ex
@@ -31,6 +31,7 @@ defmodule Fuschia.Entities.UserToken do
   The token is valid for a week as long as users don't change
   their email.
   """
+  @spec build_email_token(%User{}, String.t()) :: {String.t(), %__MODULE__{}}
   def build_email_token(user, context) do
     build_hashed_token(user, context, user.contato.email)
   end

--- a/lib/fuschia/jobs/mailer_job.ex
+++ b/lib/fuschia/jobs/mailer_job.ex
@@ -24,8 +24,8 @@ defmodule Fuschia.Jobs.MailerJob do
   def perform(%{args: args}) do
     Logger.info("==> [MailerJob] Sending email...")
 
-    Mailer.new_email(
-      args["to"],
+    args["to"]
+    |> Mailer.new_email(
       args["subject"],
       args["layout"],
       args["template"],

--- a/lib/fuschia/mailer/html.ex
+++ b/lib/fuschia/mailer/html.ex
@@ -7,7 +7,7 @@ defmodule Fuschia.Mailer.HTML do
   the resulting HTML page into a base template.
   Returns an HTML page in string format.
   """
-  @spec assemble_body(String.t(), String.t(), map) :: any
+  @spec assemble_body(String.t(), String.t(), map, String.t()) :: any
   def assemble_body(project, email, assigns, base \\ "base") when is_map(assigns) do
     assigns
     |> rewrite_name()
@@ -16,6 +16,7 @@ defmodule Fuschia.Mailer.HTML do
     |> render_layout(base)
   end
 
+  @spec templates_path :: String.t()
   def templates_path, do: "#{:code.priv_dir(:fuschia)}/templates"
 
   defp pea_pescarte_contact do

--- a/lib/fuschia/parser.ex
+++ b/lib/fuschia/parser.ex
@@ -83,8 +83,7 @@ defmodule Fuschia.Parser do
   """
   @spec map_to_keyword(map) :: keyword
   def map_to_keyword(map) when is_map(map) do
-    map
-    |> Enum.map(fn {k, v} ->
+    Enum.map(map, fn {k, v} ->
       k = apply_if(k, is_binary(k), &String.to_existing_atom/1)
       {k, v}
     end)

--- a/lib/fuschia/parser.ex
+++ b/lib/fuschia/parser.ex
@@ -134,7 +134,7 @@ defmodule Fuschia.Parser do
   """
   @spec reject_empty(map) :: map
   def reject_empty(map) when is_map(map) do
-    :maps.filter(fn _, v -> !is_nil(v) end, map)
+    :maps.filter(fn _key, v -> !is_nil(v) end, map)
   end
 
   ####         ####
@@ -144,7 +144,7 @@ defmodule Fuschia.Parser do
   @spec to_boolean(String.t()) :: boolean | nil
   def to_boolean("true"), do: true
   def to_boolean("false"), do: false
-  def to_boolean(_), do: nil
+  def to_boolean(_invalid), do: nil
 
   # Only execute a function if the condition is truthy
   # otherwise returns the same value

--- a/lib/fuschia/release.ex
+++ b/lib/fuschia/release.ex
@@ -5,6 +5,7 @@ defmodule Fuschia.Release do
 
   @app :fuschia
 
+  @spec migrate :: keyword
   def migrate do
     load_app()
 
@@ -13,6 +14,7 @@ defmodule Fuschia.Release do
     end
   end
 
+  @spec rollback(atom, String.t()) :: {:ok, any, list(atom)}
   def rollback(repo, version) do
     load_app()
     {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))

--- a/lib/fuschia/schema.ex
+++ b/lib/fuschia/schema.ex
@@ -41,7 +41,7 @@ defmodule Fuschia.Schema do
         dgettext("errors", "does not exist")
       )
     else
-      _ ->
+      _err ->
         changeset
     end
   end

--- a/lib/fuschia/schema.ex
+++ b/lib/fuschia/schema.ex
@@ -15,6 +15,8 @@ defmodule Fuschia.Schema do
     end
   end
 
+  defguardp is_valid_fk?(fk) when is_integer(fk) or is_binary(fk)
+
   @doc """
   Validates foreign keys using the respective `context` and `field_name`.
 
@@ -31,7 +33,7 @@ defmodule Fuschia.Schema do
   """
   @spec validate_foreign_key(Ecto.Changeset.t(), module, atom) :: Ecto.Changeset.t()
   def validate_foreign_key(changeset, context, field_name) do
-    with field_id when not is_nil(field_id) <- Ecto.Changeset.get_field(changeset, field_name),
+    with field_id when is_valid_fk?(field_id) <- Ecto.Changeset.get_field(changeset, field_name),
          nil <- context.one(field_id) do
       Ecto.Changeset.add_error(
         changeset,

--- a/lib/fuschia/types/capitalized_string.ex
+++ b/lib/fuschia/types/capitalized_string.ex
@@ -7,8 +7,10 @@ defmodule Fuschia.Types.CapitalizedString do
 
   @behaviour Ecto.Type
 
+  @spec type :: :string
   def type, do: :string
 
+  @spec cast(any) :: {:ok, any} | {:error, keyword}
   def cast(binary) when is_binary(binary) do
     {:ok,
      binary
@@ -18,13 +20,17 @@ defmodule Fuschia.Types.CapitalizedString do
 
   def cast(other), do: Ecto.Type.cast(:string, other)
 
+  @spec load(any) :: {:ok, any} | :error
   def load(data), do: Ecto.Type.load(:string, data)
 
+  @spec dump(any) :: {:ok, any} | :error
   def dump(data), do: Ecto.Type.dump(:string, data)
 
+  @spec equal?(String.t() | nil, String.t() | nil) :: bool
   def equal?(x, y) when is_nil(x) and is_binary(y), do: false
   def equal?(x, y) when is_binary(x) and is_nil(y), do: false
   def equal?(x, y), do: x == y
 
+  @spec embed_as(any) :: :self
   def embed_as(_format), do: :self
 end

--- a/lib/fuschia/types/trimmed_string.ex
+++ b/lib/fuschia/types/trimmed_string.ex
@@ -5,18 +5,24 @@ defmodule Fuschia.Types.TrimmedString do
 
   @behaviour Ecto.Type
 
+  @spec type :: :string
   def type, do: :string
 
+  @spec cast(any) :: {:ok, any} | {:error, keyword}
   def cast(binary) when is_binary(binary), do: {:ok, String.trim(binary)}
   def cast(other), do: Ecto.Type.cast(:string, other)
 
+  @spec load(any) :: {:ok, any} | :error
   def load(data), do: Ecto.Type.load(:string, data)
 
+  @spec dump(any) :: {:ok, any} | :error
   def dump(data), do: Ecto.Type.dump(:string, data)
 
+  @spec equal?(String.t() | nil, String.t() | nil) :: bool
   def equal?(x, y) when is_nil(x) and is_binary(y), do: false
   def equal?(x, y) when is_binary(x) and is_nil(y), do: false
   def equal?(x, y), do: x == y
 
+  @spec embed_as(any) :: :self
   def embed_as(_format), do: :self
 end

--- a/lib/fuschia/types/upcased_string.ex
+++ b/lib/fuschia/types/upcased_string.ex
@@ -5,8 +5,10 @@ defmodule Fuschia.Types.UpcaseString do
 
   @behaviour Ecto.Type
 
+  @spec type :: :string
   def type, do: :string
 
+  @spec cast(any) :: {:ok, any} | {:error, keyword}
   def cast(binary) when is_binary(binary) do
     {:ok,
      binary
@@ -16,13 +18,17 @@ defmodule Fuschia.Types.UpcaseString do
 
   def cast(other), do: Ecto.Type.cast(:string, other)
 
+  @spec load(any) :: {:ok, any} | :error
   def load(data), do: Ecto.Type.load(:string, data)
 
+  @spec dump(any) :: {:ok, any} | :error
   def dump(data), do: Ecto.Type.dump(:string, data)
 
+  @spec equal?(String.t() | nil, String.t() | nil) :: bool
   def equal?(x, y) when is_nil(x) and is_binary(y), do: false
   def equal?(x, y) when is_binary(x) and is_nil(y), do: false
   def equal?(x, y), do: x == y
 
+  @spec embed_as(any) :: :self
   def embed_as(_format), do: :self
 end

--- a/lib/fuschia_web.ex
+++ b/lib/fuschia_web.ex
@@ -22,6 +22,7 @@ defmodule FuschiaWeb do
 
   alias FuschiaWeb.FuschiaView
 
+  @spec controller :: Macro.t()
   def controller do
     quote do
       use Phoenix.Controller, namespace: FuschiaWeb
@@ -33,6 +34,7 @@ defmodule FuschiaWeb do
     end
   end
 
+  @spec view :: Macro.t()
   def view do
     quote do
       use Phoenix.View,
@@ -48,6 +50,7 @@ defmodule FuschiaWeb do
     end
   end
 
+  @spec router :: Macro.t()
   def router do
     quote do
       use Phoenix.Router
@@ -57,6 +60,7 @@ defmodule FuschiaWeb do
     end
   end
 
+  @spec channel :: Macro.t()
   def channel do
     quote do
       use Phoenix.Channel

--- a/lib/fuschia_web/auth/error_handler.ex
+++ b/lib/fuschia_web/auth/error_handler.ex
@@ -7,6 +7,7 @@ defmodule FuschiaWeb.Auth.ErrorHandler do
 
   @behaviour Guardian.Plug.ErrorHandler
 
+  @spec auth_error(Plug.Conn.t(), {any, any}, map) :: Plug.Conn.t()
   def auth_error(conn, {type, _reason}, _opts) do
     body = Jason.encode!(%{message: to_string(type)})
 

--- a/lib/fuschia_web/auth/guardian.ex
+++ b/lib/fuschia_web/auth/guardian.ex
@@ -8,6 +8,7 @@ defmodule FuschiaWeb.Auth.Guardian do
   alias Fuschia.Context.Users
   alias Fuschia.Entities.User
 
+  @spec subject_for_token(User.t(), map) :: {:ok, String.t()}
   def subject_for_token(user, _claims) do
     sub = to_string(user.cpf)
 
@@ -24,6 +25,7 @@ defmodule FuschiaWeb.Auth.Guardian do
     {:ok, user}
   end
 
+  @spec authenticate(map) :: {:ok, String.t()} | {:error, :unauthorized}
   def authenticate(%{"cpf" => cpf, "password" => password}) do
     case Users.one_by_cpf(cpf) do
       nil -> {:error, :unauthorized}
@@ -31,6 +33,7 @@ defmodule FuschiaWeb.Auth.Guardian do
     end
   end
 
+  @spec user_claims(map) :: {:ok, User.t()} | {:error, :unauthorized}
   def user_claims(%{"cpf" => cpf}) do
     case Users.one_with_permissions(cpf) do
       nil -> {:error, :unauthorized}
@@ -38,12 +41,14 @@ defmodule FuschiaWeb.Auth.Guardian do
     end
   end
 
+  @spec create_token(User.t()) :: {:ok, String.t()}
   def create_token(user) do
     {:ok, token, _claims} = encode_and_sign(user)
 
     {:ok, token}
   end
 
+  @spec validate_password(User.t(), String.t()) :: {:ok, String.t()} | {:error, :unauthorized}
   defp validate_password(_user, ""), do: {:error, :unauthorized}
 
   defp validate_password(user, password) when is_binary(password) do

--- a/lib/fuschia_web/auth/guardian.ex
+++ b/lib/fuschia_web/auth/guardian.ex
@@ -32,9 +32,9 @@ defmodule FuschiaWeb.Auth.Guardian do
   end
 
   def user_claims(%{"cpf" => cpf}) do
-    case user = Users.one_with_permissions(cpf) do
+    case Users.one_with_permissions(cpf) do
       nil -> {:error, :unauthorized}
-      _ -> {:ok, User.for_jwt(user)}
+      user -> {:ok, User.for_jwt(user)}
     end
   end
 
@@ -52,7 +52,7 @@ defmodule FuschiaWeb.Auth.Guardian do
          true <- Bcrypt.verify_pass(password, user.password_hash) do
       create_token(user)
     else
-      _ -> {:error, :unauthorized}
+      _invalid_password -> {:error, :unauthorized}
     end
   end
 

--- a/lib/fuschia_web/channels/user_socket.ex
+++ b/lib/fuschia_web/channels/user_socket.ex
@@ -15,7 +15,7 @@ defmodule FuschiaWeb.UserSocket do
   #
   # See `Phoenix.Token` documentation for examples in
   # performing token verification on connect.
-  @impl true
+  @impl Phoenix.Socket
   def connect(_params, socket, _connect_info) do
     {:ok, socket}
   end
@@ -30,6 +30,6 @@ defmodule FuschiaWeb.UserSocket do
   #     FuschiaWeb.Endpoint.broadcast("user_socket:#{user.cpf}", "disconnect", %{})
   #
   # Returning `nil` makes this socket anonymous.
-  @impl true
+  @impl Phoenix.Socket
   def id(_socket), do: nil
 end

--- a/lib/fuschia_web/controllers/auth_controller.ex
+++ b/lib/fuschia_web/controllers/auth_controller.ex
@@ -19,6 +19,7 @@ defmodule FuschiaWeb.AuthController do
   @doc """
   Parse headers before handling the route
   """
+  @spec action(Plug.Conn.t(), map) :: Plug.Conn.t()
   def action(conn, _params) do
     ip = RemoteIp.get(conn)
     user_agent = UserAgent.get(conn)
@@ -40,6 +41,7 @@ defmodule FuschiaWeb.AuthController do
       ] ++ Response.errors(:unauthorized)
   )
 
+  @spec login(Plug.Conn.t(), String.t(), String.t(), map) :: Plug.Conn.t()
   def login(conn, ip, user_agent, params) do
     with {:ok, token} <- Guardian.authenticate(params),
          {:ok, user} <- Guardian.user_claims(params),
@@ -60,6 +62,7 @@ defmodule FuschiaWeb.AuthController do
       ] ++ Response.errors(:unauthorized)
   )
 
+  @spec signup(Plug.Conn.t(), String.t(), String.t(), map) :: Plug.Conn.t()
   def signup(conn, _ip, _user_agent, params) do
     with {:ok, user} <- Users.register(params) do
       render_response(user, conn, :created)

--- a/lib/fuschia_web/controllers/auth_controller.ex
+++ b/lib/fuschia_web/controllers/auth_controller.ex
@@ -19,7 +19,7 @@ defmodule FuschiaWeb.AuthController do
   @doc """
   Parse headers before handling the route
   """
-  def action(conn, _) do
+  def action(conn, _params) do
     ip = RemoteIp.get(conn)
     user_agent = UserAgent.get(conn)
     args = [conn, ip, user_agent, conn.params]

--- a/lib/fuschia_web/controllers/fallback_controller.ex
+++ b/lib/fuschia_web/controllers/fallback_controller.ex
@@ -7,6 +7,7 @@ defmodule FuschiaWeb.FallbackController do
 
   alias FuschiaWeb.ErrorView
 
+  @spec call(Plug.Conn.t(), {:error, any} | Ecto.Changeset.t()) :: map
   def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
     conn
     |> put_status(:unprocessable_entity)

--- a/lib/fuschia_web/plugs/health_check.ex
+++ b/lib/fuschia_web/plugs/health_check.ex
@@ -4,8 +4,10 @@ defmodule FuschiaWeb.HealthCheck do
   """
   import Plug.Conn
 
+  @spec init(map) :: map
   def init(options), do: options
 
+  @spec call(Plug.Conn.t(), map) :: Plug.Conn.t()
   def call(%Plug.Conn{request_path: "/health-check"} = conn, _opts) do
     conn
     |> send_resp(200, "")

--- a/lib/fuschia_web/plugs/locale.ex
+++ b/lib/fuschia_web/plugs/locale.ex
@@ -7,8 +7,10 @@ defmodule FuschiaWeb.LocalePlug do
 
   @default_locale "en"
 
+  @spec init(map) :: map
   def init(default), do: default
 
+  @spec call(Plug.Conn.t(), map) :: map
   def call(conn, _opts) do
     req_locale =
       conn

--- a/lib/fuschia_web/plugs/locale.ex
+++ b/lib/fuschia_web/plugs/locale.ex
@@ -11,7 +11,8 @@ defmodule FuschiaWeb.LocalePlug do
 
   def call(conn, _opts) do
     req_locale =
-      get_req_header(conn, "accept-language")
+      conn
+      |> get_req_header("accept-language")
       |> List.first()
 
     locale = req_locale || @default_locale

--- a/lib/fuschia_web/plugs/require_api_key.ex
+++ b/lib/fuschia_web/plugs/require_api_key.ex
@@ -15,12 +15,12 @@ defmodule FuschiaWeb.RequireApiKeyPlug do
 
   def call(conn, _opts) do
     conn = fetch_query_params(conn)
-    api_key = conn.query_params["api_key"] || get_req_header(conn, "x-api-key") |> List.first()
+    api_key = conn.query_params["api_key"] || conn |> get_req_header("x-api-key") |> List.first()
 
     case api_key && ApiKeys.one_by_key(api_key) do
       nil ->
-        send_resp(
-          conn,
+        conn
+        |> send_resp(
           :unauthorized,
           gettext("You need a valid API Key to access this endpoint")
         )

--- a/lib/fuschia_web/plugs/require_api_key.ex
+++ b/lib/fuschia_web/plugs/require_api_key.ex
@@ -9,10 +9,10 @@ defmodule FuschiaWeb.RequireApiKeyPlug do
 
   alias Fuschia.Context.ApiKeys
 
-  def init(options) do
-    options
-  end
+  @spec init(map) :: map
+  def init(options), do: options
 
+  @spec call(Plug.Conn.t(), map) :: Plug.Conn.t()
   def call(conn, _opts) do
     conn = fetch_query_params(conn)
     api_key = conn.query_params["api_key"] || conn |> get_req_header("x-api-key") |> List.first()

--- a/lib/fuschia_web/plugs/require_api_key.ex
+++ b/lib/fuschia_web/plugs/require_api_key.ex
@@ -26,7 +26,7 @@ defmodule FuschiaWeb.RequireApiKeyPlug do
         )
         |> halt()
 
-      _ ->
+      _api_key ->
         conn
     end
   end

--- a/lib/fuschia_web/remote_ip.ex
+++ b/lib/fuschia_web/remote_ip.ex
@@ -42,7 +42,7 @@ defmodule FuschiaWeb.RemoteIp do
     ip =
       case Regex.named_captures(@port_regex, ip_and_port) do
         %{"port" => port} -> String.trim_trailing(ip_and_port, port)
-        _ -> ip_and_port
+        _unmatch -> ip_and_port
       end
 
     ip

--- a/lib/fuschia_web/remote_ip.ex
+++ b/lib/fuschia_web/remote_ip.ex
@@ -14,8 +14,7 @@ defmodule FuschiaWeb.RemoteIp do
 
     cond do
       cf_connecting_ip ->
-        cf_connecting_ip
-        |> clean_ip
+        clean_ip(cf_connecting_ip)
 
       forwarded_for ->
         forwarded_for

--- a/lib/fuschia_web/remote_ip.ex
+++ b/lib/fuschia_web/remote_ip.ex
@@ -7,6 +7,7 @@ defmodule FuschiaWeb.RemoteIp do
   @doc """
   Get client real IP looking up for main known proxy headers
   """
+  @spec get(Plug.Conn.t()) :: String.t()
   def get(conn) do
     cf_connecting_ip = List.first(Plug.Conn.get_req_header(conn, "cf-connecting-ip"))
     forwarded_for = List.first(Plug.Conn.get_req_header(conn, "x-forwarded-for"))
@@ -21,7 +22,7 @@ defmodule FuschiaWeb.RemoteIp do
         |> String.split(",")
         |> Enum.map(&String.trim/1)
         |> List.first()
-        |> clean_ip
+        |> clean_ip()
 
       # IPv6 addresses are enclosed in quote marks and square brackets: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
       forwarded ->
@@ -29,7 +30,7 @@ defmodule FuschiaWeb.RemoteIp do
         |> Regex.named_captures(forwarded)
         |> Map.get("for")
         |> String.trim("\"")
-        |> clean_ip
+        |> clean_ip()
 
       true ->
         to_string(:inet_parse.ntoa(conn.remote_ip))

--- a/lib/fuschia_web/swagger/api_spec.ex
+++ b/lib/fuschia_web/swagger/api_spec.ex
@@ -8,7 +8,7 @@ defmodule FuschiaWeb.Swagger.ApiSpec do
 
   @impl OpenApi
   def spec do
-    %OpenApi{
+    OpenApiSpex.resolve_schema_modules(%OpenApi{
       components: %Components{
         securitySchemes: %{
           "api_key_header" => %SecurityScheme{
@@ -35,7 +35,6 @@ defmodule FuschiaWeb.Swagger.ApiSpec do
         version: "0.0.1"
       },
       paths: Paths.from_router(Router)
-    }
-    |> OpenApiSpex.resolve_schema_modules()
+    })
   end
 end

--- a/lib/fuschia_web/swagger/security.ex
+++ b/lib/fuschia_web/swagger/security.ex
@@ -4,6 +4,7 @@ defmodule FuschiaWeb.Swagger.Security do
   @doc """
   Default security for public endpoints
   """
+  @spec public :: list(map)
   def public do
     [
       %{"api_key_header" => []},
@@ -14,6 +15,7 @@ defmodule FuschiaWeb.Swagger.Security do
   @doc """
   Default security for private endpoints
   """
+  @spec private :: list(map)
   def private do
     [
       %{"authorization" => []},

--- a/lib/fuschia_web/telemetry.ex
+++ b/lib/fuschia_web/telemetry.ex
@@ -6,11 +6,13 @@ defmodule FuschiaWeb.Telemetry do
   use Supervisor
   import Telemetry.Metrics
 
+  @spec start_link(list) :: {:ok, pid} | {:error, any}
   def start_link(arg) do
     Supervisor.start_link(__MODULE__, arg, name: __MODULE__)
   end
 
-  @impl true
+  @impl Supervisor
+  @spec init(any) :: {:ok, tuple}
   def init(_arg) do
     children = [
       # Telemetry poller will execute the given period measurements
@@ -23,6 +25,7 @@ defmodule FuschiaWeb.Telemetry do
     Supervisor.init(children, strategy: :one_for_one)
   end
 
+  @spec metrics :: list
   def metrics do
     [
       # Phoenix Metrics

--- a/lib/fuschia_web/user_agent.ex
+++ b/lib/fuschia_web/user_agent.ex
@@ -4,6 +4,7 @@ defmodule FuschiaWeb.UserAgent do
   @doc """
   Get the user-agent request header
   """
+  @spec get(Plug.Conn.t()) :: String.t()
   def get(conn) do
     conn
     |> Plug.Conn.get_req_header("user-agent")

--- a/lib/fuschia_web/views/error_helpers.ex
+++ b/lib/fuschia_web/views/error_helpers.ex
@@ -6,6 +6,7 @@ defmodule FuschiaWeb.ErrorHelpers do
   @doc """
   Translates an error message using gettext.
   """
+  @spec translate_error(map) :: String.t()
   def translate_error({msg, opts}) do
     if count = opts[:count] do
       Gettext.dngettext(FuschiaWeb.Gettext, "errors", msg, msg, count, opts)

--- a/lib/fuschia_web/views/error_view.ex
+++ b/lib/fuschia_web/views/error_view.ex
@@ -1,6 +1,7 @@
 defmodule FuschiaWeb.ErrorView do
   use FuschiaWeb, :view
 
+  @spec translate_errors(Ecto.Changeset.t()) :: list(map)
   def translate_errors(changeset) do
     Ecto.Changeset.traverse_errors(changeset, &translate_error/1)
   end
@@ -8,6 +9,7 @@ defmodule FuschiaWeb.ErrorView do
   @doc """
   Error for template not found
   """
+  @spec template_not_found(String.t(), map) :: map
   def template_not_found(template, _assigns) do
     %{
       error: %{
@@ -19,6 +21,7 @@ defmodule FuschiaWeb.ErrorView do
   @doc """
   Error for Ecto Changeset validation
   """
+  @spec render(String.t(), map) :: map
   def render("error.json", %{changeset: %Ecto.Changeset{} = changeset}) do
     %{
       error: %{

--- a/lib/fuschia_web/views/fuschia_view.ex
+++ b/lib/fuschia_web/views/fuschia_view.ex
@@ -1,6 +1,7 @@
 defmodule FuschiaWeb.FuschiaView do
   use FuschiaWeb, :view
 
+  @spec render(String.t(), map) :: map
   def render("response.json", %{data: data}) do
     %{
       data: data

--- a/test/fuschia/entities/user_test.exs
+++ b/test/fuschia/entities/user_test.exs
@@ -42,7 +42,8 @@ defmodule Fuschia.Entities.UserTest do
       contato = params_for(:contato)
 
       default_params =
-        params_for(:user)
+        :user
+        |> params_for()
         |> Map.put(:contato, contato)
         |> Map.put(:perfil, "admin")
 
@@ -68,7 +69,8 @@ defmodule Fuschia.Entities.UserTest do
       contato = params_for(:contato)
 
       default_params =
-        params_for(:user)
+        :user
+        |> params_for()
         |> Map.put(:contato, contato)
         |> Map.merge(%{password: "minhaSenha123", password_confirmation: "minhaSenha123"})
 

--- a/test/fuschia/mailer_test.exs
+++ b/test/fuschia/mailer_test.exs
@@ -37,7 +37,8 @@ defmodule Fuschia.MailerTest.GenerateTests do
     template_path = "#{:code.priv_dir(:fuschia)}/templates"
     path = Path.expand("#{template_path}/email/#{project}", __DIR__)
 
-    Path.wildcard(path <> "/*")
+    (path <> "/*")
+    |> Path.wildcard()
     |> Enum.map(&String.replace(&1, [path <> "/", ".html.eex"], ""))
   end
 end
@@ -49,7 +50,8 @@ defmodule Fuschia.MailerTest do
 
   test "add_attachment/2 always returns the email structure" do
     assert %Email{} =
-             Mailer.new_email(nil, nil, "user", "confirmation", @general_assigns)
+             nil
+             |> Mailer.new_email(nil, "user", "confirmation", @general_assigns)
              |> Mailer.add_attachment("")
   end
 end

--- a/test/fuschia/mailer_test.exs
+++ b/test/fuschia/mailer_test.exs
@@ -33,6 +33,7 @@ defmodule Fuschia.MailerTest.GenerateTests do
     end
   end
 
+  @spec emails(String.t()) :: list(String.t())
   def emails(project) do
     template_path = "#{:code.priv_dir(:fuschia)}/templates"
     path = Path.expand("#{template_path}/email/#{project}", __DIR__)

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -47,6 +47,7 @@ defmodule Fuschia.DataCase do
       assert %{password: ["password is too short"]} = errors_on(changeset)
 
   """
+  @spec errors_on(Ecto.Changeset.t()) :: list(map)
   def errors_on(changeset) do
     Ecto.Changeset.traverse_errors(changeset, fn {message, opts} ->
       Regex.replace(~r"%{(\w+)}", message, fn _fst, key ->

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -49,7 +49,7 @@ defmodule Fuschia.DataCase do
   """
   def errors_on(changeset) do
     Ecto.Changeset.traverse_errors(changeset, fn {message, opts} ->
-      Regex.replace(~r"%{(\w+)}", message, fn _, key ->
+      Regex.replace(~r"%{(\w+)}", message, fn _fst, key ->
         opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
       end)
     end)

--- a/test/support/factories/auth_log_factory.ex
+++ b/test/support/factories/auth_log_factory.ex
@@ -5,6 +5,7 @@ defmodule Fuschia.AuthLogFactory do
 
   defmacro __using__(_opts) do
     quote do
+      @spec auth_log_factory :: AuthLog.t()
       def auth_log_factory do
         user_agent =
           "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36"

--- a/test/support/factories/campus_factory.ex
+++ b/test/support/factories/campus_factory.ex
@@ -5,6 +5,7 @@ defmodule Fuschia.CampusFactory do
     quote do
       alias Fuschia.Entities.Campus
 
+      @spec campus_factory :: Campus.t()
       def campus_factory do
         cidade = insert(:cidade)
 

--- a/test/support/factories/cidade_factory.ex
+++ b/test/support/factories/cidade_factory.ex
@@ -5,6 +5,7 @@ defmodule Fuschia.CidadeFactory do
     quote do
       alias Fuschia.Entities.Cidade
 
+      @spec cidade_factory :: Cidade.t()
       def cidade_factory do
         %Cidade{
           municipio: sequence(:municipio, &"Cidade #{&1}")

--- a/test/support/factories/contato_factory.ex
+++ b/test/support/factories/contato_factory.ex
@@ -5,6 +5,7 @@ defmodule Fuschia.ContatoFactory do
     quote do
       alias Fuschia.Entities.Contato
 
+      @spec contato_factory :: Contato.t()
       def contato_factory do
         %Contato{
           email: sequence(:email, &"test-#{&1}@example.com"),

--- a/test/support/factories/linha_pesquisa_factory.ex
+++ b/test/support/factories/linha_pesquisa_factory.ex
@@ -5,6 +5,7 @@ defmodule Fuschia.LinhaPesquisaFactory do
     quote do
       alias Fuschia.Entities.LinhaPesquisa
 
+      @spec linha_pesquisa_factory :: LinhaPesquisa.t()
       def linha_pesquisa_factory do
         nucleo = insert(:nucleo)
 

--- a/test/support/factories/nucleo_factory.ex
+++ b/test/support/factories/nucleo_factory.ex
@@ -5,6 +5,7 @@ defmodule Fuschia.NucleoFactory do
     quote do
       alias Fuschia.Entities.Nucleo
 
+      @spec nucleo_factory :: Nucleo.t()
       def nucleo_factory do
         %Nucleo{
           nome: sequence(:nome, &"Nucleo #{&1}"),

--- a/test/support/factories/pesquisador_factory.ex
+++ b/test/support/factories/pesquisador_factory.ex
@@ -5,6 +5,7 @@ defmodule Fuschia.PesquisadorFactory do
     quote do
       alias Fuschia.Entities.Pesquisador
 
+      @spec pesquisador_factory :: Pesquisador.t()
       def pesquisador_factory do
         campus = insert(:campus)
         usuario = build(:user)

--- a/test/support/factories/user_factory.ex
+++ b/test/support/factories/user_factory.ex
@@ -5,6 +5,7 @@ defmodule Fuschia.UserFactory do
     quote do
       alias Fuschia.Entities.User
 
+      @spec user_factory :: User.t()
       def user_factory do
         %User{
           perfil: sequence(:perfil, ["avulso", "pesquisador"]),

--- a/test/support/test_support.ex
+++ b/test/support/test_support.ex
@@ -19,7 +19,7 @@ defmodule CoreWeb.TestSupport do
          {:ok, _user} <- Guardian.user_claims(params) do
       put_req_header(conn, "authorization", "Bearer #{token}")
     else
-      _ -> {:error, "Couldn't login"}
+      _err -> {:error, "Couldn't login"}
     end
   end
 

--- a/test/support/test_support.ex
+++ b/test/support/test_support.ex
@@ -17,8 +17,7 @@ defmodule CoreWeb.TestSupport do
 
     with {:ok, token} <- Guardian.authenticate(params),
          {:ok, _user} <- Guardian.user_claims(params) do
-      conn
-      |> put_req_header("authorization", "Bearer #{token}")
+      put_req_header(conn, "authorization", "Bearer #{token}")
     else
       _ -> {:error, "Couldn't login"}
     end


### PR DESCRIPTION
# Descrição
Ativa algumas checagens adicionais do [credo](https://hexdocs.pm/credo/overview.html) que realiza verificações de estilo, possibilidades de refatoração, entre outros.

Além da ativação das checagens, também houveram diversas refatorações para que a aplicação se adeque às novas regras.


## Stories relacionadas (Shortcut)
- [sc-xxxx]


## Pontos para atenção
N/A


## Possui novas configurações?
- Extrai a configuração padrão do `credo` no arquivo `.credo.exs`


## Possui migrations?
N/A
